### PR TITLE
New regex to match link on new website

### DIFF
--- a/Shure_Wireless_Workbench/ShureWirelessWorkbench6.download.recipe
+++ b/Shure_Wireless_Workbench/ShureWirelessWorkbench6.download.recipe
@@ -9,7 +9,7 @@
     <key>Input</key>
     <dict>
         <key>SEARCH_PATTERN</key>
-        <string>(?P&lt;url&gt;\/software\/wireless-workbench-mac-v(?P&lt;version&gt;[\d.]+)\.zip)</string>
+        <string>&lt;a href="https?:\/\/www.shure.com(?P&lt;url&gt;[a-zA-Z\-\.\/]+)"&gt;Wireless Workbench (?P&lt;version&gt;[0-9\.]+) \(macOS\)&lt;/a&gt;</string>
         <key>SEARCH_PAGE</key>
         <string>https://www.shure.com/americas/products/software/wireless-workbench/wireless-workbench-6#downloads</string>
         <key>NAME</key>


### PR DESCRIPTION
Shure updated their website and this recipe was failing due to that.  Good news, the file is consistent now.  Bad news, the version number is harder to find.  I updated the regex to match the link and version on the new website/file structure they have setup.

This is tested and working for me.