### PR TITLE
Basic python3 compatibility

### DIFF
--- a/SharedProcessors/unearthVersioner.py
+++ b/SharedProcessors/unearthVersioner.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
+
 import os.path
 import subprocess
 

--- a/SharedProcessors/unearthVersioner.py
+++ b/SharedProcessors/unearthVersioner.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import os.path
 import subprocess
 

--- a/SharedProcessors/unearthVersioner.py
+++ b/SharedProcessors/unearthVersioner.py
@@ -14,33 +14,33 @@ class unearthVersioner(Processor):
         "source_path": {
             "required": False,
             "description": "Full path to unearth executable. Defaults to %pkgroot%/usr/local/bin/unearth/unearth. "
-    	}
+        }
     }
     output_variables = {
-    	"version": {
-    		"description": "The unearth executable version"
-    	}
+        "version": {
+            "description": "The unearth executable version"
+        }
     }
 
     __doc__ = description
 
     def main(self):
-		if not self.env['source_path']:
-			self.env['source_path'] = os.path.join(self.env['pkgroot'], "/usr/local/bin/unearth/unearth")
+        if not self.env['source_path']:
+            self.env['source_path'] = os.path.join(self.env['pkgroot'], "/usr/local/bin/unearth/unearth")
 
-		self.output("unearth path: %s" % self.env['source_path'])
+        self.output("unearth path: %s" % self.env['source_path'])
 
-		if os.path.exists(self.env['source_path']):
-			self.output("Found unearth executable at %s" % self.env['source_path'])
-			try:
-				cmd = subprocess.check_output(['/usr/bin/python', self.env['source_path'], '-v'])
-				self.env['version'] = cmd.replace('\n', '')
-				self.output("Version: %s" % self.env['version'])
-			except OSError as e:
-				raise ProcessorError("Can't find %s" % (self.env['source_path'], e.strerror))
-		else:
-			raise ProcessorError("Could not find unearth executable at %s" % (self.env['source_path'], e.strerror))
-	
+        if os.path.exists(self.env['source_path']):
+            self.output("Found unearth executable at %s" % self.env['source_path'])
+            try:
+                cmd = subprocess.check_output(['/usr/bin/python', self.env['source_path'], '-v'])
+                self.env['version'] = cmd.replace('\n', '')
+                self.output("Version: %s" % self.env['version'])
+            except OSError:
+                raise ProcessorError("Can't find %s" % (self.env['source_path']))
+        else:
+            raise ProcessorError("Could not find unearth executable at %s" % (self.env['source_path']))
+
 if __name__ == '__main__':
     processor = unearthVersioner()
     processor.execute_shell()


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later, but this should catch the low-hanging fruit right now.