### PR TITLE
Add CodeSignatureVerifier processor

### DIFF
--- a/GeoGebra/GeoGebra6.download.recipe
+++ b/GeoGebra/GeoGebra6.download.recipe
@@ -49,8 +49,6 @@
             <string>Unarchiver</string>
         </dict>
         <dict>
-            <key>Processor</key>
-            <string>CodeSignatureVerifier</string>
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
@@ -58,6 +56,8 @@
                 <key>requirements</key>
                 <string>identifier "org.geogebra6.mac" and anchor apple generic and certificate leaf[subject.CN] = "3rd Party Mac Developer Application: Internationales GeoGebra Institut, \"IGI\" (T9W862P4D2)" and certificate 1[field.1.2.840.113635.100.6.2.1] /* exists */</string>
             </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
         </dict>
         <dict>
             <key>Arguments</key>

--- a/GeoGebra/GeoGebra6.download.recipe
+++ b/GeoGebra/GeoGebra6.download.recipe
@@ -49,6 +49,17 @@
             <string>Unarchiver</string>
         </dict>
         <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/GeoGebra Classic 6.app</string>
+                <key>requirements</key>
+                <string>identifier "org.geogebra6.mac" and anchor apple generic and certificate leaf[subject.CN] = "3rd Party Mac Developer Application: Internationales GeoGebra Institut, \"IGI\" (T9W862P4D2)" and certificate 1[field.1.2.840.113635.100.6.2.1] /* exists */</string>
+            </dict>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>dmg_megabytes</key>

--- a/GeoGebra/GeoGebraGeometry.download.recipe
+++ b/GeoGebra/GeoGebraGeometry.download.recipe
@@ -49,6 +49,17 @@
             <string>Unarchiver</string>
         </dict>
         <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/GeoGebra Geometry.app</string>
+                <key>requirements</key>
+                <string>identifier "org.geogebra.mac.geometry" and anchor apple generic and certificate leaf[subject.CN] = "3rd Party Mac Developer Application: Internationales GeoGebra Institut, \"IGI\" (T9W862P4D2)" and certificate 1[field.1.2.840.113635.100.6.2.1] /* exists */</string>
+            </dict>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>dmg_megabytes</key>

--- a/GeoGebra/GeoGebraGeometry.download.recipe
+++ b/GeoGebra/GeoGebraGeometry.download.recipe
@@ -49,8 +49,6 @@
             <string>Unarchiver</string>
         </dict>
         <dict>
-            <key>Processor</key>
-            <string>CodeSignatureVerifier</string>
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
@@ -58,6 +56,8 @@
                 <key>requirements</key>
                 <string>identifier "org.geogebra.mac.geometry" and anchor apple generic and certificate leaf[subject.CN] = "3rd Party Mac Developer Application: Internationales GeoGebra Institut, \"IGI\" (T9W862P4D2)" and certificate 1[field.1.2.840.113635.100.6.2.1] /* exists */</string>
             </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
         </dict>
         <dict>
             <key>Arguments</key>

--- a/GeoGebra/GeoGebraGraphingCalculator.download.recipe
+++ b/GeoGebra/GeoGebraGraphingCalculator.download.recipe
@@ -49,8 +49,6 @@
             <string>Unarchiver</string>
         </dict>
         <dict>
-            <key>Processor</key>
-            <string>CodeSignatureVerifier</string>
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
@@ -58,6 +56,8 @@
                 <key>requirements</key>
                 <string>identifier "org.geogebra.mac.graphing" and anchor apple generic and certificate leaf[subject.CN] = "3rd Party Mac Developer Application: Internationales GeoGebra Institut, \"IGI\" (T9W862P4D2)" and certificate 1[field.1.2.840.113635.100.6.2.1] /* exists */</string>
             </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
         </dict>
         <dict>
             <key>Arguments</key>

--- a/GeoGebra/GeoGebraGraphingCalculator.download.recipe
+++ b/GeoGebra/GeoGebraGraphingCalculator.download.recipe
@@ -49,6 +49,17 @@
             <string>Unarchiver</string>
         </dict>
         <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/GeoGebra Graphing Calculator.app</string>
+                <key>requirements</key>
+                <string>identifier "org.geogebra.mac.graphing" and anchor apple generic and certificate leaf[subject.CN] = "3rd Party Mac Developer Application: Internationales GeoGebra Institut, \"IGI\" (T9W862P4D2)" and certificate 1[field.1.2.840.113635.100.6.2.1] /* exists */</string>
+            </dict>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>dmg_megabytes</key>

--- a/Stage_Plot_Pro/StagePlotPro-5Place.download.recipe
+++ b/Stage_Plot_Pro/StagePlotPro-5Place.download.recipe
@@ -40,8 +40,6 @@
             <string>EndOfCheckPhase</string>
         </dict>
         <dict>
-            <key>Processor</key>
-            <string>CodeSignatureVerifier</string>
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
@@ -49,6 +47,8 @@
                 <key>requirements</key>
                 <string>identifier "com.divertisma.StagePlotPro" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "584DQZP443"</string>
             </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
         </dict>
         <dict>
             <key>Arguments</key>

--- a/Stage_Plot_Pro/StagePlotPro-5Place.download.recipe
+++ b/Stage_Plot_Pro/StagePlotPro-5Place.download.recipe
@@ -40,6 +40,17 @@
             <string>EndOfCheckPhase</string>
         </dict>
         <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/StagePlotPro_5-place_Mac.app</string>
+                <key>requirements</key>
+                <string>identifier "com.divertisma.StagePlotPro" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "584DQZP443"</string>
+            </dict>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>dmg_path</key>


### PR DESCRIPTION
Context: The [CodeSignatureVerifier](https://github.com/autopkg/autopkg/wiki/Using-CodeSignatureVerification) processor ensures that the downloaded applications/packages are signed by the expected developer certificate. Although this is not a guarantee that the payload is trouble-free, it's a good indicator that the file you downloaded is the one you intended to download.