### PR TITLE
Unity support component recipes

### DIFF
--- a/Unity/Unity3DAndroidSupport.download.recipe
+++ b/Unity/Unity3DAndroidSupport.download.recipe
@@ -23,7 +23,7 @@
                 <key>url</key>
                 <string>https://unity3d.com/unity-release/latest</string>
                 <key>re_pattern</key>
-                <string>(?P&lt;url&gt;https:\/\/[a-z0-9]+\.unity3d\.com\/download\/.*\/UnitySetup-Android-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
+                <string>(?P&lt;url&gt;https:\/\/[a-z0-9]+\.unity3d\.com\/.*\/UnitySetup-Android-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
             </dict>
         </dict>
         <dict>

--- a/Unity/Unity3DAndroidSupport.download.recipe
+++ b/Unity/Unity3DAndroidSupport.download.recipe
@@ -2,15 +2,15 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>Description</key>
+    <string>Downloads the latest version of the Unity Android Target Support installer.</string>
+    <key>Identifier</key>
+    <string>com.github.apizz.autopkg.download.Unity3DAndroid</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
         <string>Unity3D_AndroidSupport</string>
     </dict>
-    <key>Description</key>
-    <string>Downloads the latest version of the Unity Android Target Support installer.</string>
-    <key>Identifier</key>
-    <string>com.github.apizz.autopkg.download.Unity3DAndroid</string>
     <key>MinimumVersion</key>
     <string>0.5.0</string>
     <key>Process</key>

--- a/Unity/Unity3DAndroidSupport.munki.recipe
+++ b/Unity/Unity3DAndroidSupport.munki.recipe
@@ -72,6 +72,14 @@ RECEIPT="%RECEIPT_PATH%/Unity3D_android_version.txt"
 VERSION="%version%"
 
 echo "$VERSION" > "$RECEIPT"</string>
+                    <key>postuninstall_script</key>
+                    <string>#!/bin/bash
+# Remove receipt
+RECEIPT="%RECEIPT_PATH%/Unity3D_android_version.txt"
+
+if [ -f "$RECEIPT" ]; then
+    rm "$RECEIPT"
+fi</string>
                     <key>update_for</key>
                     <array>
                         <string>%UNITY_MUNKI_ITEM_NAME%-%version%</string>

--- a/Unity/Unity3DAndroidSupport.munki.recipe
+++ b/Unity/Unity3DAndroidSupport.munki.recipe
@@ -71,7 +71,7 @@ fi</string>
 RECEIPT="%RECEIPT_PATH%/Unity3D_android_version.txt"
 VERSION="%version%"
 
-echo "$VERSION" > "$RECEIPT"</string>
+echo "$VERSION" &gt; "$RECEIPT"</string>
                     <key>postuninstall_script</key>
                     <string>#!/bin/bash
 # Remove receipt

--- a/Unity/Unity3DAppleTVSupport.download.recipe
+++ b/Unity/Unity3DAppleTVSupport.download.recipe
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of the Unity Apple TV Target Support installer.</string>
+    <key>Identifier</key>
+    <string>com.github.apizz.autopkg.download.Unity3DAppleTV</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>Unity3D_AppleTVSupport</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.5.0</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>https://unity3d.com/unity-release/latest</string>
+                <key>re_pattern</key>
+                <string>(?P&lt;url&gt;https:\/\/[a-z0-9]+\.unity3d\.com\/download\/.*\/UnitySetup-AppleTV-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>%url%</string>
+                <key>filename</key>
+                <string>%NAME%.pkg</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>expected_authority_names</key>
+                <array>
+                    <string>Developer ID Installer: Unity Technologies ApS (BVPN9UFA9B)</string>
+                    <string>Developer ID Certification Authority</string>
+                    <string>Apple Root CA</string>
+                </array>
+                <key>input_path</key>
+                <string>%pathname%</string>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Unity/Unity3DAppleTVSupport.download.recipe
+++ b/Unity/Unity3DAppleTVSupport.download.recipe
@@ -23,7 +23,7 @@
                 <key>url</key>
                 <string>https://unity3d.com/unity-release/latest</string>
                 <key>re_pattern</key>
-                <string>(?P&lt;url&gt;https:\/\/[a-z0-9]+\.unity3d\.com\/download\/.*\/UnitySetup-AppleTV-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
+                <string>(?P&lt;url&gt;https:\/\/[a-z0-9]+\.unity3d\.com\/.*\/UnitySetup-AppleTV-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
             </dict>
         </dict>
         <dict>

--- a/Unity/Unity3DAppleTVSupport.munki.recipe
+++ b/Unity/Unity3DAppleTVSupport.munki.recipe
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Download the latest version of the Unity Apple TV Support pkg and imports it into a munki_repo.
+
+Need to supply the munki item name for Unity 3D in UNITY_MUNKI_ITEM_NAME to correctly link this support installer to it along with the correct version.
+
+A preinstall script in this support package checks to make sure the same version of Unity 3D is installed, otherwise it fails.</string>
+    <key>Identifier</key>
+    <string>com.github.apizz.autopkg.munki.Unity3DAppleTV</string>
+    <key>Input</key>
+    <dict>
+        <key>MUNKI_CATEGORY</key>
+        <string>Development</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps-content/unity</string>
+        <key>NAME</key>
+        <string>Unity3D_AppleTVSupport</string>
+        <key>RECEIPT_PATH</key>
+        <string>/Library/Receipts</string>
+        <key>UNITY_MUNKI_ITEM_NAME</key>
+        <string>munki_item_name_here</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>category</key>
+            <string>%MUNKI_CATEGORY%</string>
+            <key>developer</key>
+            <string>Unity Technologies</string>
+            <key>display_name</key>
+            <string>Unity 3D - Apple TV Support</string>
+            <key>description</key>
+            <string>Apple TV Support component for Unity 3D.</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true/>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.2.9</string>
+    <key>ParentRecipe</key>
+    <string>com.github.apizz.autopkg.download.Unity3DAppleTV</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>installcheck_script</key>
+                    <string>#!/bin/bash
+# Check for existing receipt and version
+RECEIPT="%RECEIPT_PATH%/Unity3D_appletv_version.txt"
+INSTALLED_VERSION=$(cat "$RECEIPT")
+VERSION="%version%"
+
+if [ ! -f "$RECEIPT" ] || [ "$INSTALLED_VERSION" != "$VERSION" ] &amp;&amp; [[ "$INSTALLED_VERSION" &lt; "$VERSION" ]]; then
+    exit 0
+else
+    exit 1
+fi</string>
+                    <key>postinstall_script</key>
+                    <string>#!/bin/bash
+# Write version receipt to reference in installcheck_script as pkg receipt has no version
+RECEIPT="%RECEIPT_PATH%/Unity3D_appletv_version.txt"
+VERSION="%version%"
+
+echo "$VERSION" > "$RECEIPT"</string>
+                    <key>postuninstall_script</key>
+                    <string>#!/bin/bash
+# Remove receipt
+RECEIPT="%RECEIPT_PATH%/Unity3D_appletv_version.txt"
+
+if [ -f "$RECEIPT" ]; then
+    rm "$RECEIPT"
+fi</string>
+                    <key>update_for</key>
+                    <array>
+                        <string>%UNITY_MUNKI_ITEM_NAME%-%version%</string>
+                    </array>
+                    <key>version</key>
+                    <string>%version%</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%pathname%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Unity/Unity3DAppleTVSupport.munki.recipe
+++ b/Unity/Unity3DAppleTVSupport.munki.recipe
@@ -71,7 +71,7 @@ fi</string>
 RECEIPT="%RECEIPT_PATH%/Unity3D_appletv_version.txt"
 VERSION="%version%"
 
-echo "$VERSION" > "$RECEIPT"</string>
+echo "$VERSION" &gt; "$RECEIPT"</string>
                     <key>postuninstall_script</key>
                     <string>#!/bin/bash
 # Remove receipt

--- a/Unity/Unity3DFacebookGamesSupport.download.recipe
+++ b/Unity/Unity3DFacebookGamesSupport.download.recipe
@@ -23,7 +23,7 @@
                 <key>url</key>
                 <string>https://unity3d.com/unity-release/latest</string>
                 <key>re_pattern</key>
-                <string>(?P&lt;url&gt;https:\/\/[a-z0-9]+\.unity3d\.com\/download\/.*\/UnitySetup-Facebook-Games-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
+                <string>(?P&lt;url&gt;https:\/\/[a-z0-9]+\.unity3d\.com\/.*\/UnitySetup-Facebook-Games-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
             </dict>
         </dict>
         <dict>

--- a/Unity/Unity3DFacebookGamesSupport.download.recipe
+++ b/Unity/Unity3DFacebookGamesSupport.download.recipe
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of the Unity Apple TV Target Support installer.</string>
+    <key>Identifier</key>
+    <string>com.github.apizz.autopkg.download.Unity3DFacebook</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>Unity3D_FacebookGamesSupport</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.5.0</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>https://unity3d.com/unity-release/latest</string>
+                <key>re_pattern</key>
+                <string>(?P&lt;url&gt;https:\/\/[a-z0-9]+\.unity3d\.com\/download\/.*\/UnitySetup-Facebook-Games-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>%url%</string>
+                <key>filename</key>
+                <string>%NAME%.pkg</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>expected_authority_names</key>
+                <array>
+                    <string>Developer ID Installer: Unity Technologies ApS (BVPN9UFA9B)</string>
+                    <string>Developer ID Certification Authority</string>
+                    <string>Apple Root CA</string>
+                </array>
+                <key>input_path</key>
+                <string>%pathname%</string>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Unity/Unity3DFacebookGamesSupport.munki.recipe
+++ b/Unity/Unity3DFacebookGamesSupport.munki.recipe
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Download the latest version of the Unity Facebook Games Support pkg and imports it into a munki_repo.
+
+Need to supply the munki item name for Unity 3D in UNITY_MUNKI_ITEM_NAME to correctly link this support installer to it along with the correct version.
+
+A preinstall script in this support package checks to make sure the same version of Unity 3D is installed, otherwise it fails.</string>
+    <key>Identifier</key>
+    <string>com.github.apizz.autopkg.munki.Unity3DFacebook</string>
+    <key>Input</key>
+    <dict>
+        <key>MUNKI_CATEGORY</key>
+        <string>Development</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps-content/unity</string>
+        <key>NAME</key>
+        <string>Unity3D_FacebookGamesSupport</string>
+        <key>RECEIPT_PATH</key>
+        <string>/Library/Receipts</string>
+        <key>UNITY_MUNKI_ITEM_NAME</key>
+        <string>munki_item_name_here</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>category</key>
+            <string>%MUNKI_CATEGORY%</string>
+            <key>developer</key>
+            <string>Unity Technologies</string>
+            <key>display_name</key>
+            <string>Unity 3D - Facebook Games Support</string>
+            <key>description</key>
+            <string>Facebook Games Support component for Unity 3D.</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true/>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.2.9</string>
+    <key>ParentRecipe</key>
+    <string>com.github.apizz.autopkg.download.Unity3DFacebook</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>installcheck_script</key>
+                    <string>#!/bin/bash
+# Check for existing receipt and version
+RECEIPT="%RECEIPT_PATH%/Unity3D_facebook_version.txt"
+INSTALLED_VERSION=$(cat "$RECEIPT")
+VERSION="%version%"
+
+if [ ! -f "$RECEIPT" ] || [ "$INSTALLED_VERSION" != "$VERSION" ] &amp;&amp; [[ "$INSTALLED_VERSION" &lt; "$VERSION" ]]; then
+    exit 0
+else
+    exit 1
+fi</string>
+                    <key>postinstall_script</key>
+                    <string>#!/bin/bash
+# Write version receipt to reference in installcheck_script as pkg receipt has no version
+RECEIPT="%RECEIPT_PATH%/Unity3D_facebook_version.txt"
+VERSION="%version%"
+
+echo "$VERSION" > "$RECEIPT"</string>
+                    <key>postuninstall_script</key>
+                    <string>#!/bin/bash
+# Remove receipt
+RECEIPT="%RECEIPT_PATH%/Unity3D_facebook_version.txt"
+
+if [ -f "$RECEIPT" ]; then
+    rm "$RECEIPT"
+fi</string>
+                    <key>update_for</key>
+                    <array>
+                        <string>%UNITY_MUNKI_ITEM_NAME%-%version%</string>
+                    </array>
+                    <key>version</key>
+                    <string>%version%</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%pathname%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Unity/Unity3DFacebookGamesSupport.munki.recipe
+++ b/Unity/Unity3DFacebookGamesSupport.munki.recipe
@@ -71,7 +71,7 @@ fi</string>
 RECEIPT="%RECEIPT_PATH%/Unity3D_facebook_version.txt"
 VERSION="%version%"
 
-echo "$VERSION" > "$RECEIPT"</string>
+echo "$VERSION" &gt; "$RECEIPT"</string>
                     <key>postuninstall_script</key>
                     <string>#!/bin/bash
 # Remove receipt

--- a/Unity/Unity3DLinuxSupport.download.recipe
+++ b/Unity/Unity3DLinuxSupport.download.recipe
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of the Unity Linux Target Support installer.</string>
+    <key>Identifier</key>
+    <string>com.github.apizz.autopkg.download.Unity3DLinux</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>Unity3D_LinuxSupport</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.5.0</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>https://unity3d.com/unity-release/latest</string>
+                <key>re_pattern</key>
+                <string>(?P&lt;url&gt;https:\/\/[a-z0-9]+\.unity3d\.com\/download\/.*\/UnitySetup-Linux-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>%url%</string>
+                <key>filename</key>
+                <string>%NAME%.pkg</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>expected_authority_names</key>
+                <array>
+                    <string>Developer ID Installer: Unity Technologies ApS (BVPN9UFA9B)</string>
+                    <string>Developer ID Certification Authority</string>
+                    <string>Apple Root CA</string>
+                </array>
+                <key>input_path</key>
+                <string>%pathname%</string>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Unity/Unity3DLinuxSupport.download.recipe
+++ b/Unity/Unity3DLinuxSupport.download.recipe
@@ -23,7 +23,7 @@
                 <key>url</key>
                 <string>https://unity3d.com/unity-release/latest</string>
                 <key>re_pattern</key>
-                <string>(?P&lt;url&gt;https:\/\/[a-z0-9]+\.unity3d\.com\/download\/.*\/UnitySetup-Linux-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
+                <string>(?P&lt;url&gt;https:\/\/[a-z0-9]+\.unity3d\.com\/.*\/UnitySetup-Linux-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
             </dict>
         </dict>
         <dict>

--- a/Unity/Unity3DLinuxSupport.munki.recipe
+++ b/Unity/Unity3DLinuxSupport.munki.recipe
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Download the latest version of the Unity Linux Support pkg and imports it into a munki_repo.
+
+Need to supply the munki item name for Unity 3D in UNITY_MUNKI_ITEM_NAME to correctly link this support installer to it along with the correct version.
+
+A preinstall script in this support package checks to make sure the same version of Unity 3D is installed, otherwise it fails.</string>
+    <key>Identifier</key>
+    <string>com.github.apizz.autopkg.munki.Unity3DLinux</string>
+    <key>Input</key>
+    <dict>
+        <key>MUNKI_CATEGORY</key>
+        <string>Development</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps-content/unity</string>
+        <key>NAME</key>
+        <string>Unity3D_LinuxSupport</string>
+        <key>RECEIPT_PATH</key>
+        <string>/Library/Receipts</string>
+        <key>UNITY_MUNKI_ITEM_NAME</key>
+        <string>munki_item_name_here</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>category</key>
+            <string>%MUNKI_CATEGORY%</string>
+            <key>developer</key>
+            <string>Unity Technologies</string>
+            <key>display_name</key>
+            <string>Unity 3D - Linux Support</string>
+            <key>description</key>
+            <string>Linux Support component for Unity 3D.</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true/>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.2.9</string>
+    <key>ParentRecipe</key>
+    <string>com.github.apizz.autopkg.download.Unity3DLinux</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>installcheck_script</key>
+                    <string>#!/bin/bash
+# Check for existing receipt and version
+RECEIPT="%RECEIPT_PATH%/Unity3D_linux_version.txt"
+INSTALLED_VERSION=$(cat "$RECEIPT")
+VERSION="%version%"
+
+if [ ! -f "$RECEIPT" ] || [ "$INSTALLED_VERSION" != "$VERSION" ] &amp;&amp; [[ "$INSTALLED_VERSION" &lt; "$VERSION" ]]; then
+    exit 0
+else
+    exit 1
+fi</string>
+                    <key>postinstall_script</key>
+                    <string>#!/bin/bash
+# Write version receipt to reference in installcheck_script as pkg receipt has no version
+RECEIPT="%RECEIPT_PATH%/Unity3D_linux_version.txt"
+VERSION="%version%"
+
+echo "$VERSION" > "$RECEIPT"</string>
+                    <key>postuninstall_script</key>
+                    <string>#!/bin/bash
+# Remove receipt
+RECEIPT="%RECEIPT_PATH%/Unity3D_linux_version.txt"
+
+if [ -f "$RECEIPT" ]; then
+    rm "$RECEIPT"
+fi</string>
+                    <key>update_for</key>
+                    <array>
+                        <string>%UNITY_MUNKI_ITEM_NAME%-%version%</string>
+                    </array>
+                    <key>version</key>
+                    <string>%version%</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%pathname%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Unity/Unity3DLinuxSupport.munki.recipe
+++ b/Unity/Unity3DLinuxSupport.munki.recipe
@@ -71,7 +71,7 @@ fi</string>
 RECEIPT="%RECEIPT_PATH%/Unity3D_linux_version.txt"
 VERSION="%version%"
 
-echo "$VERSION" > "$RECEIPT"</string>
+echo "$VERSION" &gt; "$RECEIPT"</string>
                     <key>postuninstall_script</key>
                     <string>#!/bin/bash
 # Remove receipt

--- a/Unity/Unity3DLuminSupport.download.recipe
+++ b/Unity/Unity3DLuminSupport.download.recipe
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of the Unity Lumin Target Support installer.</string>
+    <key>Identifier</key>
+    <string>com.github.apizz.autopkg.download.Unity3DLumin</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>Unity3D_LuminSupport</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.5.0</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>https://unity3d.com/unity-release/latest</string>
+                <key>re_pattern</key>
+                <string>(?P&lt;url&gt;https:\/\/[a-z0-9]+\.unity3d\.com\/download\/.*\/UnitySetup-Lumin-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>%url%</string>
+                <key>filename</key>
+                <string>%NAME%.pkg</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>expected_authority_names</key>
+                <array>
+                    <string>Developer ID Installer: Unity Technologies ApS (BVPN9UFA9B)</string>
+                    <string>Developer ID Certification Authority</string>
+                    <string>Apple Root CA</string>
+                </array>
+                <key>input_path</key>
+                <string>%pathname%</string>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Unity/Unity3DLuminSupport.download.recipe
+++ b/Unity/Unity3DLuminSupport.download.recipe
@@ -23,7 +23,7 @@
                 <key>url</key>
                 <string>https://unity3d.com/unity-release/latest</string>
                 <key>re_pattern</key>
-                <string>(?P&lt;url&gt;https:\/\/[a-z0-9]+\.unity3d\.com\/download\/.*\/UnitySetup-Lumin-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
+                <string>(?P&lt;url&gt;https:\/\/[a-z0-9]+\.unity3d\.com\/.*\/UnitySetup-Lumin-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
             </dict>
         </dict>
         <dict>

--- a/Unity/Unity3DLuminSupport.munki.recipe
+++ b/Unity/Unity3DLuminSupport.munki.recipe
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Download the latest version of the Unity Lumin Support pkg and imports it into a munki_repo.
+
+Need to supply the munki item name for Unity 3D in UNITY_MUNKI_ITEM_NAME to correctly link this support installer to it along with the correct version.
+
+A preinstall script in this support package checks to make sure the same version of Unity 3D is installed, otherwise it fails.</string>
+    <key>Identifier</key>
+    <string>com.github.apizz.autopkg.munki.Unity3DLumin</string>
+    <key>Input</key>
+    <dict>
+        <key>MUNKI_CATEGORY</key>
+        <string>Development</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps-content/unity</string>
+        <key>NAME</key>
+        <string>Unity3D_LuminSupport</string>
+        <key>RECEIPT_PATH</key>
+        <string>/Library/Receipts</string>
+        <key>UNITY_MUNKI_ITEM_NAME</key>
+        <string>munki_item_name_here</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>category</key>
+            <string>%MUNKI_CATEGORY%</string>
+            <key>developer</key>
+            <string>Unity Technologies</string>
+            <key>display_name</key>
+            <string>Unity 3D - Lumin Support</string>
+            <key>description</key>
+            <string>Lumin Support component for Unity 3D.</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true/>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.2.9</string>
+    <key>ParentRecipe</key>
+    <string>com.github.apizz.autopkg.download.Unity3DLumin</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>installcheck_script</key>
+                    <string>#!/bin/bash
+# Check for existing receipt and version
+RECEIPT="%RECEIPT_PATH%/Unity3D_lumin_version.txt"
+INSTALLED_VERSION=$(cat "$RECEIPT")
+VERSION="%version%"
+
+if [ ! -f "$RECEIPT" ] || [ "$INSTALLED_VERSION" != "$VERSION" ] &amp;&amp; [[ "$INSTALLED_VERSION" &lt; "$VERSION" ]]; then
+    exit 0
+else
+    exit 1
+fi</string>
+                    <key>postinstall_script</key>
+                    <string>#!/bin/bash
+# Write version receipt to reference in installcheck_script as pkg receipt has no version
+RECEIPT="%RECEIPT_PATH%/Unity3D_lumin_version.txt"
+VERSION="%version%"
+
+echo "$VERSION" > "$RECEIPT"</string>
+                    <key>postuninstall_script</key>
+                    <string>#!/bin/bash
+# Remove receipt
+RECEIPT="%RECEIPT_PATH%/Unity3D_lumin_version.txt"
+
+if [ -f "$RECEIPT" ]; then
+    rm "$RECEIPT"
+fi</string>
+                    <key>update_for</key>
+                    <array>
+                        <string>%UNITY_MUNKI_ITEM_NAME%-%version%</string>
+                    </array>
+                    <key>version</key>
+                    <string>%version%</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%pathname%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Unity/Unity3DLuminSupport.munki.recipe
+++ b/Unity/Unity3DLuminSupport.munki.recipe
@@ -71,7 +71,7 @@ fi</string>
 RECEIPT="%RECEIPT_PATH%/Unity3D_lumin_version.txt"
 VERSION="%version%"
 
-echo "$VERSION" > "$RECEIPT"</string>
+echo "$VERSION" &gt; "$RECEIPT"</string>
                     <key>postuninstall_script</key>
                     <string>#!/bin/bash
 # Remove receipt

--- a/Unity/Unity3DWebGLSupport.download.recipe
+++ b/Unity/Unity3DWebGLSupport.download.recipe
@@ -23,7 +23,7 @@
                 <key>url</key>
                 <string>https://unity3d.com/unity-release/latest</string>
                 <key>re_pattern</key>
-                <string>(?P&lt;url&gt;https:\/\/[a-z0-9]+\.unity3d\.com\/download\/.*\/UnitySetup-WebGL-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
+                <string>(?P&lt;url&gt;https:\/\/[a-z0-9]+\.unity3d\.com\/.*\/UnitySetup-WebGL-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
             </dict>
         </dict>
         <dict>

--- a/Unity/Unity3DWebGLSupport.download.recipe
+++ b/Unity/Unity3DWebGLSupport.download.recipe
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of the Unity WebGL Target Support installer.</string>
+    <key>Identifier</key>
+    <string>com.github.apizz.autopkg.download.Unity3DWebGL</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>Unity3D_WebGLSupport</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.5.0</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>https://unity3d.com/unity-release/latest</string>
+                <key>re_pattern</key>
+                <string>(?P&lt;url&gt;https:\/\/[a-z0-9]+\.unity3d\.com\/download\/.*\/UnitySetup-WebGL-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>%url%</string>
+                <key>filename</key>
+                <string>%NAME%.pkg</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>expected_authority_names</key>
+                <array>
+                    <string>Developer ID Installer: Unity Technologies ApS (BVPN9UFA9B)</string>
+                    <string>Developer ID Certification Authority</string>
+                    <string>Apple Root CA</string>
+                </array>
+                <key>input_path</key>
+                <string>%pathname%</string>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Unity/Unity3DWebGLSupport.munki.recipe
+++ b/Unity/Unity3DWebGLSupport.munki.recipe
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Download the latest version of the Unity WebGL Support pkg and imports it into a munki_repo.
+
+Need to supply the munki item name for Unity 3D in UNITY_MUNKI_ITEM_NAME to correctly link this support installer to it along with the correct version.
+
+A preinstall script in this support package checks to make sure the same version of Unity 3D is installed, otherwise it fails.</string>
+    <key>Identifier</key>
+    <string>com.github.apizz.autopkg.munki.Unity3DWebGL</string>
+    <key>Input</key>
+    <dict>
+        <key>MUNKI_CATEGORY</key>
+        <string>Development</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps-content/unity</string>
+        <key>NAME</key>
+        <string>Unity3D_WebGLSupport</string>
+        <key>RECEIPT_PATH</key>
+        <string>/Library/Receipts</string>
+        <key>UNITY_MUNKI_ITEM_NAME</key>
+        <string>munki_item_name_here</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>category</key>
+            <string>%MUNKI_CATEGORY%</string>
+            <key>developer</key>
+            <string>Unity Technologies</string>
+            <key>display_name</key>
+            <string>Unity 3D - WebGL Support</string>
+            <key>description</key>
+            <string>WebGL Support component for Unity 3D.</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true/>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.2.9</string>
+    <key>ParentRecipe</key>
+    <string>com.github.apizz.autopkg.download.Unity3DWebGL</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>installcheck_script</key>
+                    <string>#!/bin/bash
+# Check for existing receipt and version
+RECEIPT="%RECEIPT_PATH%/Unity3D_webgl_version.txt"
+INSTALLED_VERSION=$(cat "$RECEIPT")
+VERSION="%version%"
+
+if [ ! -f "$RECEIPT" ] || [ "$INSTALLED_VERSION" != "$VERSION" ] &amp;&amp; [[ "$INSTALLED_VERSION" &lt; "$VERSION" ]]; then
+    exit 0
+else
+    exit 1
+fi</string>
+                    <key>postinstall_script</key>
+                    <string>#!/bin/bash
+# Write version receipt to reference in installcheck_script as pkg receipt has no version
+RECEIPT="%RECEIPT_PATH%/Unity3D_webgl_version.txt"
+VERSION="%version%"
+
+echo "$VERSION" > "$RECEIPT"</string>
+                    <key>postuninstall_script</key>
+                    <string>#!/bin/bash
+# Remove receipt
+RECEIPT="%RECEIPT_PATH%/Unity3D_webgl_version.txt"
+
+if [ -f "$RECEIPT" ]; then
+    rm "$RECEIPT"
+fi</string>
+                    <key>update_for</key>
+                    <array>
+                        <string>%UNITY_MUNKI_ITEM_NAME%-%version%</string>
+                    </array>
+                    <key>version</key>
+                    <string>%version%</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%pathname%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Unity/Unity3DWebGLSupport.munki.recipe
+++ b/Unity/Unity3DWebGLSupport.munki.recipe
@@ -71,7 +71,7 @@ fi</string>
 RECEIPT="%RECEIPT_PATH%/Unity3D_webgl_version.txt"
 VERSION="%version%"
 
-echo "$VERSION" > "$RECEIPT"</string>
+echo "$VERSION" &gt; "$RECEIPT"</string>
                     <key>postuninstall_script</key>
                     <string>#!/bin/bash
 # Remove receipt

--- a/Unity/Unity3DWindowsSupport.download.recipe
+++ b/Unity/Unity3DWindowsSupport.download.recipe
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of the Unity Windows Target Support installer.</string>
+    <key>Identifier</key>
+    <string>com.github.apizz.autopkg.download.Unity3DWindows</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>Unity3D_WindowsSupport</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.5.0</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>https://unity3d.com/unity-release/latest</string>
+                <key>re_pattern</key>
+                <string>(?P&lt;url&gt;https:\/\/[a-z0-9]+\.unity3d\.com\/download\/.*\/UnitySetup-Windows-Mono-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>%url%</string>
+                <key>filename</key>
+                <string>%NAME%.pkg</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>expected_authority_names</key>
+                <array>
+                    <string>Developer ID Installer: Unity Technologies ApS (BVPN9UFA9B)</string>
+                    <string>Developer ID Certification Authority</string>
+                    <string>Apple Root CA</string>
+                </array>
+                <key>input_path</key>
+                <string>%pathname%</string>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Unity/Unity3DWindowsSupport.download.recipe
+++ b/Unity/Unity3DWindowsSupport.download.recipe
@@ -23,7 +23,7 @@
                 <key>url</key>
                 <string>https://unity3d.com/unity-release/latest</string>
                 <key>re_pattern</key>
-                <string>(?P&lt;url&gt;https:\/\/[a-z0-9]+\.unity3d\.com\/download\/.*\/UnitySetup-Windows-Mono-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
+                <string>(?P&lt;url&gt;https:\/\/[a-z0-9]+\.unity3d\.com\/.*\/UnitySetup-Windows-Mono-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
             </dict>
         </dict>
         <dict>

--- a/Unity/Unity3DWindowsSupport.munki.recipe
+++ b/Unity/Unity3DWindowsSupport.munki.recipe
@@ -71,7 +71,7 @@ fi</string>
 RECEIPT="%RECEIPT_PATH%/Unity3D_windows_version.txt"
 VERSION="%version%"
 
-echo "$VERSION" > "$RECEIPT"</string>
+echo "$VERSION" &gt; "$RECEIPT"</string>
                     <key>postuninstall_script</key>
                     <string>#!/bin/bash
 # Remove receipt

--- a/Unity/Unity3DWindowsSupport.munki.recipe
+++ b/Unity/Unity3DWindowsSupport.munki.recipe
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Download the latest version of the Unity Windows Support pkg and imports it into a munki_repo.
+
+Need to supply the munki item name for Unity 3D in UNITY_MUNKI_ITEM_NAME to correctly link this support installer to it along with the correct version.
+
+A preinstall script in this support package checks to make sure the same version of Unity 3D is installed, otherwise it fails.</string>
+    <key>Identifier</key>
+    <string>com.github.apizz.autopkg.munki.Unity3DWindows</string>
+    <key>Input</key>
+    <dict>
+        <key>MUNKI_CATEGORY</key>
+        <string>Development</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps-content/unity</string>
+        <key>NAME</key>
+        <string>Unity3D_WindowsSupport</string>
+        <key>RECEIPT_PATH</key>
+        <string>/Library/Receipts</string>
+        <key>UNITY_MUNKI_ITEM_NAME</key>
+        <string>munki_item_name_here</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>category</key>
+            <string>%MUNKI_CATEGORY%</string>
+            <key>developer</key>
+            <string>Unity Technologies</string>
+            <key>display_name</key>
+            <string>Unity 3D - Windows Support</string>
+            <key>description</key>
+            <string>Windows Support component for Unity 3D.</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true/>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.2.9</string>
+    <key>ParentRecipe</key>
+    <string>com.github.apizz.autopkg.download.Unity3DWindows</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>installcheck_script</key>
+                    <string>#!/bin/bash
+# Check for existing receipt and version
+RECEIPT="%RECEIPT_PATH%/Unity3D_windows_version.txt"
+INSTALLED_VERSION=$(cat "$RECEIPT")
+VERSION="%version%"
+
+if [ ! -f "$RECEIPT" ] || [ "$INSTALLED_VERSION" != "$VERSION" ] &amp;&amp; [[ "$INSTALLED_VERSION" &lt; "$VERSION" ]]; then
+    exit 0
+else
+    exit 1
+fi</string>
+                    <key>postinstall_script</key>
+                    <string>#!/bin/bash
+# Write version receipt to reference in installcheck_script as pkg receipt has no version
+RECEIPT="%RECEIPT_PATH%/Unity3D_windows_version.txt"
+VERSION="%version%"
+
+echo "$VERSION" > "$RECEIPT"</string>
+                    <key>postuninstall_script</key>
+                    <string>#!/bin/bash
+# Remove receipt
+RECEIPT="%RECEIPT_PATH%/Unity3D_windows_version.txt"
+
+if [ -f "$RECEIPT" ]; then
+    rm "$RECEIPT"
+fi</string>
+                    <key>update_for</key>
+                    <array>
+                        <string>%UNITY_MUNKI_ITEM_NAME%-%version%</string>
+                    </array>
+                    <key>version</key>
+                    <string>%version%</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%pathname%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Unity/Unity3DiOSSupport.download.recipe
+++ b/Unity/Unity3DiOSSupport.download.recipe
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of the Unity iOS Target Support installer.</string>
+    <key>Identifier</key>
+    <string>com.github.apizz.autopkg.download.Unity3DiOS</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>Unity3D_iOSSupport</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.5.0</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>https://unity3d.com/unity-release/latest</string>
+                <key>re_pattern</key>
+                <string>(?P&lt;url&gt;https:\/\/[a-z0-9]+\.unity3d\.com\/download\/.*\/UnitySetup-iOS-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>%url%</string>
+                <key>filename</key>
+                <string>%NAME%.pkg</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>expected_authority_names</key>
+                <array>
+                    <string>Developer ID Installer: Unity Technologies ApS (BVPN9UFA9B)</string>
+                    <string>Developer ID Certification Authority</string>
+                    <string>Apple Root CA</string>
+                </array>
+                <key>input_path</key>
+                <string>%pathname%</string>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Unity/Unity3DiOSSupport.download.recipe
+++ b/Unity/Unity3DiOSSupport.download.recipe
@@ -23,7 +23,7 @@
                 <key>url</key>
                 <string>https://unity3d.com/unity-release/latest</string>
                 <key>re_pattern</key>
-                <string>(?P&lt;url&gt;https:\/\/[a-z0-9]+\.unity3d\.com\/download\/.*\/UnitySetup-iOS-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
+                <string>(?P&lt;url&gt;https:\/\/[a-z0-9]+\.unity3d\.com\/.*\/UnitySetup-iOS-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
             </dict>
         </dict>
         <dict>

--- a/Unity/Unity3DiOSSupport.munki.recipe
+++ b/Unity/Unity3DiOSSupport.munki.recipe
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Download the latest version of the Unity iOS Support pkg and imports it into a munki_repo.
+
+Need to supply the munki item name for Unity 3D in UNITY_MUNKI_ITEM_NAME to correctly link this support installer to it along with the correct version.
+
+A preinstall script in this support package checks to make sure the same version of Unity 3D is installed, otherwise it fails.</string>
+    <key>Identifier</key>
+    <string>com.github.apizz.autopkg.munki.Unity3DiOS</string>
+    <key>Input</key>
+    <dict>
+        <key>MUNKI_CATEGORY</key>
+        <string>Development</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps-content/unity</string>
+        <key>NAME</key>
+        <string>Unity3D_iOSSupport</string>
+        <key>RECEIPT_PATH</key>
+        <string>/Library/Receipts</string>
+        <key>UNITY_MUNKI_ITEM_NAME</key>
+        <string>munki_item_name_here</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>category</key>
+            <string>%MUNKI_CATEGORY%</string>
+            <key>developer</key>
+            <string>Unity Technologies</string>
+            <key>display_name</key>
+            <string>Unity 3D - iOS Support</string>
+            <key>description</key>
+            <string>iOS Support component for Unity 3D.</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true/>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.2.9</string>
+    <key>ParentRecipe</key>
+    <string>com.github.apizz.autopkg.download.Unity3DiOS</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>installcheck_script</key>
+                    <string>#!/bin/bash
+# Check for existing receipt and version
+RECEIPT="%RECEIPT_PATH%/Unity3D_ios_version.txt"
+INSTALLED_VERSION=$(cat "$RECEIPT")
+VERSION="%version%"
+
+if [ ! -f "$RECEIPT" ] || [ "$INSTALLED_VERSION" != "$VERSION" ] &amp;&amp; [[ "$INSTALLED_VERSION" &lt; "$VERSION" ]]; then
+    exit 0
+else
+    exit 1
+fi</string>
+                    <key>postinstall_script</key>
+                    <string>#!/bin/bash
+# Write version receipt to reference in installcheck_script as pkg receipt has no version
+RECEIPT="%RECEIPT_PATH%/Unity3D_ios_version.txt"
+VERSION="%version%"
+
+echo "$VERSION" > "$RECEIPT"</string>
+                    <key>postuninstall_script</key>
+                    <string>#!/bin/bash
+# Remove receipt
+RECEIPT="%RECEIPT_PATH%/Unity3D_ios_version.txt"
+
+if [ -f "$RECEIPT" ]; then
+    rm "$RECEIPT"
+fi</string>
+                    <key>update_for</key>
+                    <array>
+                        <string>%UNITY_MUNKI_ITEM_NAME%-%version%</string>
+                    </array>
+                    <key>version</key>
+                    <string>%version%</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%pathname%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Unity/Unity3DiOSSupport.munki.recipe
+++ b/Unity/Unity3DiOSSupport.munki.recipe
@@ -71,7 +71,7 @@ fi</string>
 RECEIPT="%RECEIPT_PATH%/Unity3D_ios_version.txt"
 VERSION="%version%"
 
-echo "$VERSION" > "$RECEIPT"</string>
+echo "$VERSION" &gt; "$RECEIPT"</string>
                     <key>postuninstall_script</key>
                     <string>#!/bin/bash
 # Remove receipt

--- a/Unity/Unity3DmacOSSupport.download.recipe
+++ b/Unity/Unity3DmacOSSupport.download.recipe
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of the Unity macOS Target Support installer.</string>
+    <key>Identifier</key>
+    <string>com.github.apizz.autopkg.download.Unity3DmacOS</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>Unity3D_macOSSupport</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.5.0</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>https://unity3d.com/unity-release/latest</string>
+                <key>re_pattern</key>
+                <string>(?P&lt;url&gt;https:\/\/[a-z0-9]+\.unity3d\.com\/download\/.*\/UnitySetup-Mac-IL2CPP-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>%url%</string>
+                <key>filename</key>
+                <string>%NAME%.pkg</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>expected_authority_names</key>
+                <array>
+                    <string>Developer ID Installer: Unity Technologies ApS (BVPN9UFA9B)</string>
+                    <string>Developer ID Certification Authority</string>
+                    <string>Apple Root CA</string>
+                </array>
+                <key>input_path</key>
+                <string>%pathname%</string>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Unity/Unity3DmacOSSupport.download.recipe
+++ b/Unity/Unity3DmacOSSupport.download.recipe
@@ -23,7 +23,7 @@
                 <key>url</key>
                 <string>https://unity3d.com/unity-release/latest</string>
                 <key>re_pattern</key>
-                <string>(?P&lt;url&gt;https:\/\/[a-z0-9]+\.unity3d\.com\/download\/.*\/UnitySetup-Mac-IL2CPP-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
+                <string>(?P&lt;url&gt;https:\/\/[a-z0-9]+\.unity3d\.com\/.*\/UnitySetup-Mac-IL2CPP-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
             </dict>
         </dict>
         <dict>

--- a/Unity/Unity3DmacOSSupport.munki.recipe
+++ b/Unity/Unity3DmacOSSupport.munki.recipe
@@ -71,7 +71,7 @@ fi</string>
 RECEIPT="%RECEIPT_PATH%/Unity3D_macos_version.txt"
 VERSION="%version%"
 
-echo "$VERSION" > "$RECEIPT"</string>
+echo "$VERSION" &gt; "$RECEIPT"</string>
                     <key>postuninstall_script</key>
                     <string>#!/bin/bash
 # Remove receipt

--- a/Unity/Unity3DmacOSSupport.munki.recipe
+++ b/Unity/Unity3DmacOSSupport.munki.recipe
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Download the latest version of the Unity macOS Support pkg and imports it into a munki_repo.
+
+Need to supply the munki item name for Unity 3D in UNITY_MUNKI_ITEM_NAME to correctly link this support installer to it along with the correct version.
+
+A preinstall script in this support package checks to make sure the same version of Unity 3D is installed, otherwise it fails.</string>
+    <key>Identifier</key>
+    <string>com.github.apizz.autopkg.munki.Unity3DmacOS</string>
+    <key>Input</key>
+    <dict>
+        <key>MUNKI_CATEGORY</key>
+        <string>Development</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps-content/unity</string>
+        <key>NAME</key>
+        <string>Unity3D_macOSSupport</string>
+        <key>RECEIPT_PATH</key>
+        <string>/Library/Receipts</string>
+        <key>UNITY_MUNKI_ITEM_NAME</key>
+        <string>munki_item_name_here</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>category</key>
+            <string>%MUNKI_CATEGORY%</string>
+            <key>developer</key>
+            <string>Unity Technologies</string>
+            <key>display_name</key>
+            <string>Unity 3D - macOS Support</string>
+            <key>description</key>
+            <string>macOS Support component for Unity 3D.</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true/>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.2.9</string>
+    <key>ParentRecipe</key>
+    <string>com.github.apizz.autopkg.download.Unity3DmacOS</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>installcheck_script</key>
+                    <string>#!/bin/bash
+# Check for existing receipt and version
+RECEIPT="%RECEIPT_PATH%/Unity3D_macos_version.txt"
+INSTALLED_VERSION=$(cat "$RECEIPT")
+VERSION="%version%"
+
+if [ ! -f "$RECEIPT" ] || [ "$INSTALLED_VERSION" != "$VERSION" ] &amp;&amp; [[ "$INSTALLED_VERSION" &lt; "$VERSION" ]]; then
+    exit 0
+else
+    exit 1
+fi</string>
+                    <key>postinstall_script</key>
+                    <string>#!/bin/bash
+# Write version receipt to reference in installcheck_script as pkg receipt has no version
+RECEIPT="%RECEIPT_PATH%/Unity3D_macos_version.txt"
+VERSION="%version%"
+
+echo "$VERSION" > "$RECEIPT"</string>
+                    <key>postuninstall_script</key>
+                    <string>#!/bin/bash
+# Remove receipt
+RECEIPT="%RECEIPT_PATH%/Unity3D_macos_version.txt"
+
+if [ -f "$RECEIPT" ]; then
+    rm "$RECEIPT"
+fi</string>
+                    <key>update_for</key>
+                    <array>
+                        <string>%UNITY_MUNKI_ITEM_NAME%-%version%</string>
+                    </array>
+                    <key>version</key>
+                    <string>%version%</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%pathname%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
Add Unity component recipes given updates to [Unity3D.download.recipe](https://github.com/autopkg/joshua-d-miller-recipes/commit/414e8c82f11f46b349ac6f488959f2c867eb6777)

Munki recipes write version to text file in desired location, as pkg receipts all have a version of `0` and therefore won't install.  Achieved by utilizing the MunkiPkginfoMerger processor.

`postinstall_script` writes the receipt, `installcheck_script` verifies it's there and if not, or if the version collected is less than the latest available, installs it.

`update_for` ensures that these items are only associated with the same version of Unity3D.  `UNITY_MUNKI_ITEM_NAME` input variable allows you specify the name of the Unity item.

Ideally, want to eventually allow for more multiple`update_for` string items, but not sure how to accomplish this solely using the built-in autopkg Processors & Input variables.  I can imagine plenty of scenarios where there would be multiple Unity3D munki items for different configurations that should have some additional components associated with them, but not others. 