### PR TITLE
Added version to package name 

### DIFF
--- a/TeamViewer/TeamViewerHostCustom.pkg.recipe
+++ b/TeamViewer/TeamViewerHostCustom.pkg.recipe
@@ -46,6 +46,17 @@
         <dict>
             <key>Arguments</key>
             <dict>
+                <key>input_plist_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpack/TeamViewerHost.app/Contents/Info.plist</string>
+                <key>plist_version_key</key>
+                <string>CFBundleShortVersionString</string>
+            </dict>
+            <key>Processor</key>
+            <string>Versioner</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
                 <key>info_path</key>
                 <string>%RECIPE_CACHE_DIR%/unpack/TeamViewerHost.app/Contents/Info.plist</string>
                 <key>plist_keys</key>
@@ -63,14 +74,14 @@
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%.pkg</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%-%VERSION%.pkg</string>
                 <key>source_pkg</key>
                 <string>%RECIPE_CACHE_DIR%/downloads/%NAME%-%TEAMVIEWER_CUSTOM_ID%.pkg</string>
             </dict>
             <key>Processor</key>
             <string>PkgCopier</string>
         </dict>
-<!--        <dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>path_list</key>
@@ -80,7 +91,7 @@
             </dict>
             <key>Processor</key>
             <string>PathDeleter</string>
-        </dict>-->
+        </dict>
     </array>
 </dict>
 </plist>

--- a/TeamViewer/TeamViewerHostCustom.pkg.recipe
+++ b/TeamViewer/TeamViewerHostCustom.pkg.recipe
@@ -24,10 +24,10 @@
         <dict>
             <key>Arguments</key>
             <dict>
-            <key>destination_path</key>
-            <string>%RECIPE_CACHE_DIR%/unpack</string>
-            <key>flat_pkg_path</key>
-            <string>%pathname%</string>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpack</string>
+                <key>flat_pkg_path</key>
+                <string>%pathname%</string>
             </dict>
             <key>Processor</key>
             <string>FlatPkgUnpacker</string>

--- a/TeamViewer/TeamViewerHostCustom.pkg.recipe
+++ b/TeamViewer/TeamViewerHostCustom.pkg.recipe
@@ -46,15 +46,6 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>input_plist_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpack/TeamViewerHost.app/Contents/Info.plist</string>
-            </dict>
-            <key>Processor</key>
-            <string>Versioner</string>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
                 <key>info_path</key>
                 <string>%RECIPE_CACHE_DIR%/unpack/TeamViewerHost.app/Contents/Info.plist</string>
                 <key>plist_keys</key>
@@ -72,7 +63,7 @@
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%-%VERSION%.pkg</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
                 <key>source_pkg</key>
                 <string>%RECIPE_CACHE_DIR%/downloads/%NAME%-%TEAMVIEWER_CUSTOM_ID%.pkg</string>
             </dict>

--- a/TeamViewer/TeamViewerHostCustom.pkg.recipe
+++ b/TeamViewer/TeamViewerHostCustom.pkg.recipe
@@ -70,7 +70,7 @@
             <key>Processor</key>
             <string>PkgCopier</string>
         </dict>
-        <dict>
+<!--        <dict>
             <key>Arguments</key>
             <dict>
                 <key>path_list</key>
@@ -81,6 +81,6 @@
             <key>Processor</key>
             <string>PathDeleter</string>
         </dict>
-    </array>
+    </array>-->
 </dict>
 </plist>

--- a/TeamViewer/TeamViewerHostCustom.pkg.recipe
+++ b/TeamViewer/TeamViewerHostCustom.pkg.recipe
@@ -48,8 +48,6 @@
             <dict>
                 <key>input_plist_path</key>
                 <string>%RECIPE_CACHE_DIR%/unpack/TeamViewerHost.app/Contents/Info.plist</string>
-                <key>plist_version_key</key>
-                <string>CFBundleShortVersionString</string>
             </dict>
             <key>Processor</key>
             <string>Versioner</string>

--- a/TeamViewer/TeamViewerHostCustom.pkg.recipe
+++ b/TeamViewer/TeamViewerHostCustom.pkg.recipe
@@ -80,7 +80,7 @@
             </dict>
             <key>Processor</key>
             <string>PathDeleter</string>
-        </dict>
-    </array>-->
+        </dict>-->
+    </array>
 </dict>
 </plist>


### PR DESCRIPTION
Added version to package name to allow for minor version upgrades when deployed through Jamf Pro. Without this, Autopkg creates a package called Teamviewer.pkg and the jss_importer processor can never detect when there's a new package to upload because the name is always the same.