### PR TITLE
Update regex to accommodate HTML page change

### DIFF
--- a/Epson/EpsonScannerDriverandScanUtility-NewCert.download.recipe
+++ b/Epson/EpsonScannerDriverandScanUtility-NewCert.download.recipe
@@ -52,7 +52,9 @@ For example, the URL for the Epson Perfection V850 Pro fetched from the US Epson
                 <key>url</key>
                 <string>%SEARCH_URL%</string>
                 <key>re_pattern</key>
-                <string>Scanner Driver[^v]*v[\d.]*([\s\w="]*-){1,}[\s\w="]*(?P&lt;url&gt;https://ftp.epson.com/drivers/[\w].*\.dmg)"</string>
+                <string>Scanner Driver[^v]*v[\d.]+[\s\w="-;]+href="(https://ftp.epson.com/drivers/[\w].*\.dmg)"</string>
+                <key>result_output_var_name</key>
+                <string>url</string>
             </dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>


### PR DESCRIPTION
This parallels changes in my EpsonProDrivers.download recipe. Should be more flexible moving forward. Using the result_output_var_name should make it a little easier to read as well. Tested using Epson Expression 10000XL URL.