### PR TITLE
Adjust name of CodeSignatureVerifier argument

### DIFF
--- a/CLEditor/YamahaCLEditor.download.recipe
+++ b/CLEditor/YamahaCLEditor.download.recipe
@@ -129,7 +129,7 @@
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Applications/CL Editor.app</string>
                 <key>requirement</key>
                 <string>identifier "com.yamaha.pa.cleditor" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "5LE7A8CF65"</string>
-                <key>strict_verifications</key>
+                <key>strict_verification</key>
                 <true/>
             </dict>
             <key>Processor</key>


### PR DESCRIPTION
Correct argument name is `strict_verification`. (https://github.com/autopkg/autopkg/wiki/Processor-CodeSignatureVerifier)