### PR TITLE
Remove unused BUNDLE_ID input var

### DIFF
--- a/Lightwell/Lightwell.pkg.recipe
+++ b/Lightwell/Lightwell.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.apizz.pkg.Lightwell</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.hullabalu.Lightwell.macOS</string>
 		<key>NAME</key>
 		<string>Lightwell</string>
 	</dict>

--- a/TeacherGaming/TeacherGaming.pkg.recipe
+++ b/TeacherGaming/TeacherGaming.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.apizz.pkg.TeacherGaming</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>teachergaming.app</string>
 		<key>NAME</key>
 		<string>TeacherGaming</string>
 	</dict>


### PR DESCRIPTION
This pull request removes unused instances of `BUNDLE_ID` from recipe input variables, which will help reduce confusion by new AutoPkg users and simplify overrides created from this point on.

Making `BUNDLE_ID` available as an input variable is a common practice in AutoPkg recipes that use the [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator) processor ([example](https://github.com/autopkg/homebysix-recipes/blob/4fec9244a3af0f9b7c8f61f35a5cd7f4622fb162/soma-zone/LaunchControl.pkg.recipe#L40-L41)). It's likely that these recipes transitioned from PkgCreator to the more streamlined [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) processor some time ago, but the now-unused input variable for `BUNDLE_ID` was never removed.

Recipe run output is included below for all changed recipes (excluding jss and install recipe types). Any run failures are very likely to be unrelated to this change.

## ✅ Lightwell/Lightwell.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/apizz-recipes/Lightwell/Lightwell.pkg.recipe
Processing repos/apizz-recipes/Lightwell/Lightwell.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Lightwell.zip',
           'url': 'https://s3.amazonaws.com/lightwell/app/Lightwell.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.apizz.pkg.Lightwell/downloads/Lightwell.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.apizz.pkg.Lightwell/downloads/Lightwell.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.apizz.pkg.Lightwell/downloads/Lightwell.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.apizz.pkg.Lightwell/Lightwell',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename Lightwell.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.apizz.pkg.Lightwell/downloads/Lightwell.zip to ~/Library/AutoPkg/Cache/com.github.apizz.pkg.Lightwell/Lightwell
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.apizz.pkg.Lightwell/Lightwell/Lightwell.app',
           'requirement': 'identifier "com.hullabalu.Lightwell.macOS" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"63L83P54G7"',
           'strict_verification': True}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.apizz.pkg.Lightwell/Lightwell/Lightwell.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.apizz.pkg.Lightwell/Lightwell/Lightwell.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.apizz.pkg.Lightwell/Lightwell/Lightwell.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.apizz.pkg.Lightwell/Lightwell/Lightwell.app'}}
AppPkgCreator: Version: 1.1.1
AppPkgCreator: BundleID: com.hullabalu.Lightwell.macOS
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.apizz.pkg.Lightwell/Lightwell/Lightwell.app to ~/Library/AutoPkg/Cache/com.github.apizz.pkg.Lightwell/payload/Applications/Lightwell.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.hullabalu.Lightwell.macOS',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.apizz.pkg.Lightwell/Lightwell-1.1.1.pkg',
                                                        'version': '1.1.1'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '1.1.1'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.apizz.pkg.Lightwell/receipts/Lightwell.pkg-receipt-20210213-233202.plist

The following packages were built:
    Identifier                     Version  Pkg Path                                                                                 
    ----------                     -------  --------                                                                                 
    com.hullabalu.Lightwell.macOS  1.1.1    ~/Library/AutoPkg/Cache/com.github.apizz.pkg.Lightwell/Lightwell-1.1.1.pkg  
```

## ✅ TeacherGaming/TeacherGaming.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/apizz-recipes/TeacherGaming/TeacherGaming.pkg.recipe
Processing repos/apizz-recipes/TeacherGaming/TeacherGaming.pkg.recipe...
URLDownloader
{'Input': {'filename': 'TeacherGaming.dmg',
           'url': 'https://assets.store.teachergaming.com/desktop/app_builds/teachergaming_mac.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.apizz.pkg.TeacherGaming/downloads/TeacherGaming.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.apizz.pkg.TeacherGaming/downloads/TeacherGaming.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.apizz.pkg.TeacherGaming/downloads/TeacherGaming.dmg/TeacherGaming.app',
           'requirement': 'identifier "teachergaming.app" and certificate leaf '
                          '= H"f47df3b5856e77b28573bd874059e6794bfacbfb"',
           'strict_verification': True}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.apizz.pkg.TeacherGaming/downloads/TeacherGaming.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /private/tmp/dmg.P3F457/TeacherGaming.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.P3F457/TeacherGaming.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.P3F457/TeacherGaming.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.apizz.pkg.TeacherGaming/downloads/TeacherGaming.dmg
AppPkgCreator: Using path '/private/tmp/dmg.B6Bf7G/TeacherGaming.app' matched from globbed '/private/tmp/dmg.B6Bf7G/*.app'.
AppPkgCreator: Version: 1.1.6
AppPkgCreator: BundleID: teachergaming.app
AppPkgCreator: Copied /private/tmp/dmg.B6Bf7G/TeacherGaming.app to ~/Library/AutoPkg/Cache/com.github.apizz.pkg.TeacherGaming/payload/Applications/TeacherGaming.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'teachergaming.app',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.apizz.pkg.TeacherGaming/TeacherGaming-1.1.6.pkg',
                                                        'version': '1.1.6'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '1.1.6'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.apizz.pkg.TeacherGaming/receipts/TeacherGaming.pkg-receipt-20210213-233247.plist

The following packages were built:
    Identifier         Version  Pkg Path                                                                                         
    ----------         -------  --------                                                                                         
    teachergaming.app  1.1.6    ~/Library/AutoPkg/Cache/com.github.apizz.pkg.TeacherGaming/TeacherGaming-1.1.6.pkg  
```

