### PR TITLE
Change parent recipe for cgerke-recipes deprecation

### DIFF
--- a/Chrome_Remote_Desktop/ChromeRemoteDesktop.munki.recipe
+++ b/Chrome_Remote_Desktop/ChromeRemoteDesktop.munki.recipe
@@ -41,7 +41,7 @@
     <key>MinimumVersion</key>
     <string>1.0.0</string>
     <key>ParentRecipe</key>
-    <string>com.github.autopkg.cgerke-recipes.pkg.ChromeRemoteDesktop</string>
+    <string>com.github.homebysix.pkg.ChromeRemoteDesktop</string>
     <key>Process</key>
     <array>
         <dict>


### PR DESCRIPTION
The parent recipe has been copied to homebysix-recipes in order to prepare for cgerke-recipes deprecation. For details, see: https://github.com/autopkg/cgerke-recipes/issues/37