### PR TITLE
Adjust parent recipes for sheagcraig-recipes repo deprecation

### DIFF
--- a/VirtualBox/VirtualBox.munki.recipe
+++ b/VirtualBox/VirtualBox.munki.recipe
@@ -37,7 +37,7 @@
     <key>MinimumVersion</key>
     <string>0.5.0</string>
     <key>ParentRecipe</key>
-    <string>com.github.sheagcraig.pkg.VirtualBox</string>
+    <string>com.github.homebysix.pkg.VirtualBox</string>
     <key>Process</key>
     <array>
         <dict>

--- a/jss_helper/jss_helper.munki.recipe
+++ b/jss_helper/jss_helper.munki.recipe
@@ -37,7 +37,7 @@
     <key>MinimumVersion</key>
     <string>1.0.0</string>
     <key>ParentRecipe</key>
-    <string>com.github.sheagcraig.download.jss_helper</string>
+    <string>com.github.homebysix.download.jss_helper</string>
     <key>Process</key>
     <array>
         <dict>

--- a/yo/yo.munki.recipe
+++ b/yo/yo.munki.recipe
@@ -39,7 +39,7 @@
     <key>MinimumVersion</key>
     <string>0.5.0</string>
     <key>ParentRecipe</key>
-    <string>com.github.sheagcraig.download.yo</string>
+    <string>com.github.homebysix.download.yo</string>
     <key>Process</key>
     <array>
         <dict>


### PR DESCRIPTION
The sheagcraig-recipes repository is being deprecated (details here: https://github.com/autopkg/sheagcraig-recipes/issues/71). Many working and/or serviceable recipes have already been [copied](https://github.com/autopkg/homebysix-recipes/pull/414) to the homebysix-recipes repo. This PR changes the parent recipes in your repo to point to the homebysix-recipes version of any affected recipes.

In addition to updating trust info, users of the changed recipes will need to ensure the homebysix-recipes repo is added to their AutoPkg environment (`autopkg repo-add homebysix-recipes`).