### PR TITLE
Update VirtualBox.munki.recipe

### DIFF
--- a/VirtualBox/VirtualBox.munki.recipe
+++ b/VirtualBox/VirtualBox.munki.recipe
@@ -41,6 +41,90 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>FlatPkgUnpacker</string>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpack</string>
+                <key>flat_pkg_path</key>
+                <string>%pathname%/VirtualBox.pkg</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>PkgRootCreator</string>
+            <key>Arguments</key>
+            <dict>
+                <key>pkgdirs</key>
+                <dict>
+                    <key>Applications</key>
+                    <string>0755</string>
+                </dict>
+                <key>pkgroot</key>
+                <string>%RECIPE_CACHE_DIR%/pkgroot</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>PkgPayloadUnpacker</string>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%pkgroot%/Applications</string>
+                <key>pkg_payload_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpack/VirtualBox.pkg/Payload</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
+            <key>Arguments</key>
+            <dict>
+                <key>faux_root</key>
+                <string>%pkgroot%</string>
+                <key>version_comparison_key</key>
+                <string>CFBundleShortVersionString</string>
+                <key>installs_item_paths</key>
+                <array>
+                    <string>/Applications/VirtualBox.app</string>
+                </array>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>Versioner</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_plist_path</key>
+                <string>%pkgroot%/Applications/VirtualBox.app/Contents/Info.plist</string>
+                <key>plist_version_key</key>
+                <string>CFBundleShortVersionString</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>version</key>
+                    <string>%version%</string>
+                </dict>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>
@@ -48,8 +132,18 @@
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>
+        </dict>
+        <dict>
             <key>Processor</key>
-            <string>MunkiImporter</string>
+            <string>PathDeleter</string>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/pkgroot/</string>
+                    <string>%RECIPE_CACHE_DIR%/unpack/</string>
+                </array>
+            </dict>
         </dict>
     </array>
 </dict>


### PR DESCRIPTION
Builds an installs array based on the .app on disk and not the pkgs, tidies up afters

```
Processing /Users/ben/Git/other-recipes/apizz-recipes/VirtualBox/VirtualBox.munki.recipe...
WARNING: /Users/ben/Git/other-recipes/apizz-recipes/VirtualBox/VirtualBox.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'https://download\\.virtualbox\\.org/virtualbox/[0-9\\.]*/VirtualBox-[0-9\\.-]*-OSX.dmg',
           'url': 'https://www.virtualbox.org/wiki/Downloads'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): https://download.virtualbox.org/virtualbox/6.1.22/VirtualBox-6.1.22-144080-OSX.dmg
{'Output': {'match': 'https://download.virtualbox.org/virtualbox/6.1.22/VirtualBox-6.1.22-144080-OSX.dmg'}}
URLDownloader
{'Input': {'filename': 'VirtualBox.dmg',
           'url': 'https://download.virtualbox.org/virtualbox/6.1.22/VirtualBox-6.1.22-144080-OSX.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/downloads/VirtualBox.dmg
{'Output': {'pathname': '/Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/downloads/VirtualBox.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Oracle '
                                        'America, Inc. (VB5E2TV963)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/downloads/VirtualBox.dmg/VirtualBox.pkg'}}
CodeSignatureVerifier: Mounted disk image /Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/downloads/VirtualBox.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "VirtualBox.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2021-04-28 17:23:37 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Oracle America, Inc. (VB5E2TV963)
CodeSignatureVerifier:        Expires: 2022-06-01 12:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            4A A9 4A 85 20 2A DE 02 B2 9B 36 DA 45 00 B4 40 CF 31 43 4E 96 02
CodeSignatureVerifier:            60 6A 6D BC 02 F4 5D 3A 86 4A
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
FlatPkgUnpacker
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/unpack',
           'flat_pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/downloads/VirtualBox.dmg/*.pkg',
           'purge_destination': True}}
FlatPkgUnpacker: Mounted disk image /Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/downloads/VirtualBox.dmg
FlatPkgUnpacker: Unpacked /private/tmp/dmg.5Nx5Ob/VirtualBox.pkg to /Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/unpack
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/unpack/VirtualBox.pkg.unpacked/',
           'pkg_payload_path': '/Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/unpack/VirtualBox.pkg/Payload',
           'purge_destination': True}}
PkgPayloadUnpacker: Unpacked /Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/unpack/VirtualBox.pkg/Payload to /Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/unpack/VirtualBox.pkg.unpacked/
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '/Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/unpack/VirtualBox.pkg.unpacked/VirtualBox.app/Contents/Info.plist'}}
Versioner: No value supplied for plist_version_key, setting default value of: CFBundleShortVersionString
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Found version 6.1.22 in file /Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/unpack/VirtualBox.pkg.unpacked/VirtualBox.app/Contents/Info.plist
{'Output': {'version': '6.1.22'}}
PkgCopier
{'Input': {'pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/VirtualBox-6.1.22.pkg',
           'source_pkg': '/Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/downloads/VirtualBox.dmg/*.pkg'}}
PkgCopier: Mounted disk image /Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/downloads/VirtualBox.dmg
PkgCopier: Using path '/private/tmp/dmg.NB7J9G/VirtualBox.pkg' matched from globbed '/private/tmp/dmg.NB7J9G/*.pkg'.
PkgCopier: Copied /private/tmp/dmg.NB7J9G/VirtualBox.pkg to /Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/VirtualBox-6.1.22.pkg
{'Output': {'pkg_copier_summary_result': {'data': {'pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/VirtualBox-6.1.22.pkg'},
                                          'summary_text': 'The following '
                                                          'packages were '
                                                          'copied:'},
            'pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/VirtualBox-6.1.22.pkg'}}
FlatPkgUnpacker
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/unpack',
           'flat_pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/downloads/VirtualBox.dmg/VirtualBox.pkg',
           'purge_destination': True}}
FlatPkgUnpacker: Mounted disk image /Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/downloads/VirtualBox.dmg
FlatPkgUnpacker: Unpacked /private/tmp/dmg.IICcT6/VirtualBox.pkg to /Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/unpack
{'Output': {}}
PkgRootCreator
{'Input': {'pkgdirs': {'Applications': '0755'},
           'pkgroot': '/Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/pkgroot'}}
PkgRootCreator: Created /Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/pkgroot
PkgRootCreator: Creating Applications
PkgRootCreator: Created /Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/pkgroot/Applications
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/pkgroot/Applications',
           'pkg_payload_path': '/Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/unpack/VirtualBox.pkg/Payload',
           'purge_destination': True}}
PkgPayloadUnpacker: Unpacked /Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/unpack/VirtualBox.pkg/Payload to /Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/pkgroot/Applications
{'Output': {}}
MunkiInstallsItemsCreator
{'Input': {'faux_root': '/Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/pkgroot',
           'installs_item_paths': ['/Applications/VirtualBox.app'],
           'version_comparison_key': 'CFBundleShortVersionString'}}
MunkiInstallsItemsCreator: Created installs item for /Applications/VirtualBox.app
{'Output': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'org.virtualbox.app.VirtualBox',
                                                 'CFBundleName': 'VirtualBox',
                                                 'CFBundleShortVersionString': '6.1.22',
                                                 'CFBundleVersion': '6.1.22',
                                                 'path': '/Applications/VirtualBox.app',
                                                 'type': 'application',
                                                 'version_comparison_key': 'CFBundleShortVersionString'}]}}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'org.virtualbox.app.VirtualBox',
                                                'CFBundleName': 'VirtualBox',
                                                'CFBundleShortVersionString': '6.1.22',
                                                'CFBundleVersion': '6.1.22',
                                                'path': '/Applications/VirtualBox.app',
                                                'type': 'application',
                                                'version_comparison_key': 'CFBundleShortVersionString'}]},
           'pkginfo': {'catalogs': ['testing'],
                       'category': 'Software',
                       'description': 'Oracle VM VirtualBox is a free and '
                                      'open-source hypervisor for x86 '
                                      'computers currently being developed by '
                                      'Oracle Corporation.',
                       'developer': 'Oracle Corporation',
                       'display_name': 'VirtualBox',
                       'name': 'VirtualBox',
                       'unattended_install': True}}}
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'org.virtualbox.app.VirtualBox', 'CFBundleName': 'VirtualBox', 'CFBundleShortVersionString': '6.1.22', 'CFBundleVersion': '6.1.22', 'path': '/Applications/VirtualBox.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}]} into pkginfo
{'Output': {'pkginfo': {'catalogs': ['testing'],
                        'category': 'Software',
                        'description': 'Oracle VM VirtualBox is a free and '
                                       'open-source hypervisor for x86 '
                                       'computers currently being developed by '
                                       'Oracle Corporation.',
                        'developer': 'Oracle Corporation',
                        'display_name': 'VirtualBox',
                        'installs': [{'CFBundleIdentifier': 'org.virtualbox.app.VirtualBox',
                                      'CFBundleName': 'VirtualBox',
                                      'CFBundleShortVersionString': '6.1.22',
                                      'CFBundleVersion': '6.1.22',
                                      'path': '/Applications/VirtualBox.app',
                                      'type': 'application',
                                      'version_comparison_key': 'CFBundleShortVersionString'}],
                        'name': 'VirtualBox',
                        'unattended_install': True}}}
Versioner
{'Input': {'input_plist_path': '/Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/pkgroot/Applications/VirtualBox.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString',
           'skip_single_root_dir': False}}
Versioner: Found version 6.1.22 in file /Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/pkgroot/Applications/VirtualBox.app/Contents/Info.plist
{'Output': {'version': '6.1.22'}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'version': '6.1.22'},
           'pkginfo': {'catalogs': ['testing'],
                       'category': 'Software',
                       'description': 'Oracle VM VirtualBox is a free and '
                                      'open-source hypervisor for x86 '
                                      'computers currently being developed by '
                                      'Oracle Corporation.',
                       'developer': 'Oracle Corporation',
                       'display_name': 'VirtualBox',
                       'installs': [{'CFBundleIdentifier': 'org.virtualbox.app.VirtualBox',
                                     'CFBundleName': 'VirtualBox',
                                     'CFBundleShortVersionString': '6.1.22',
                                     'CFBundleVersion': '6.1.22',
                                     'path': '/Applications/VirtualBox.app',
                                     'type': 'application',
                                     'version_comparison_key': 'CFBundleShortVersionString'}],
                       'name': 'VirtualBox',
                       'unattended_install': True}}}
MunkiPkginfoMerger: Merged {'version': '6.1.22'} into pkginfo
{'Output': {'pkginfo': {'catalogs': ['testing'],
                        'category': 'Software',
                        'description': 'Oracle VM VirtualBox is a free and '
                                       'open-source hypervisor for x86 '
                                       'computers currently being developed by '
                                       'Oracle Corporation.',
                        'developer': 'Oracle Corporation',
                        'display_name': 'VirtualBox',
                        'installs': [{'CFBundleIdentifier': 'org.virtualbox.app.VirtualBox',
                                      'CFBundleName': 'VirtualBox',
                                      'CFBundleShortVersionString': '6.1.22',
                                      'CFBundleVersion': '6.1.22',
                                      'path': '/Applications/VirtualBox.app',
                                      'type': 'application',
                                      'version_comparison_key': 'CFBundleShortVersionString'}],
                        'name': 'VirtualBox',
                        'unattended_install': True,
                        'version': '6.1.22'}}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/downloads/VirtualBox.dmg',
           'pkginfo': {'catalogs': ['testing'],
                       'category': 'Software',
                       'description': 'Oracle VM VirtualBox is a free and '
                                      'open-source hypervisor for x86 '
                                      'computers currently being developed by '
                                      'Oracle Corporation.',
                       'developer': 'Oracle Corporation',
                       'display_name': 'VirtualBox',
                       'installs': [{'CFBundleIdentifier': 'org.virtualbox.app.VirtualBox',
                                     'CFBundleName': 'VirtualBox',
                                     'CFBundleShortVersionString': '6.1.22',
                                     'CFBundleVersion': '6.1.22',
                                     'path': '/Applications/VirtualBox.app',
                                     'type': 'application',
                                     'version_comparison_key': 'CFBundleShortVersionString'}],
                       'name': 'VirtualBox',
                       'unattended_install': True,
                       'version': '6.1.22'},
           'repo_subdirectory': 'apps',
           'version_comparison_key': 'CFBundleShortVersionString'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/VirtualBox-6.1.22__2.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/VirtualBox-6.1.22__2.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'VirtualBox',
                                                       'pkg_repo_path': 'apps/VirtualBox-6.1.22__2.dmg',
                                                       'pkginfo_path': 'apps/VirtualBox-6.1.22__2.plist',
                                                       'version': '6.1.22'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'ben',
                                         'creation_date': datetime.datetime(2021, 7, 7, 11, 7, 53),
                                         'munki_version': '5.5.0.4360',
                                         'os_version': '10.15.7'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'category': 'Software',
                           'description': 'Oracle VM VirtualBox is a free and '
                                          'open-source hypervisor for x86 '
                                          'computers currently being developed '
                                          'by Oracle Corporation.',
                           'developer': 'Oracle Corporation',
                           'display_name': 'VirtualBox',
                           'installed_size': 247450,
                           'installer_item_hash': 'c0dd1d731b12bf6d867ef09b02b8926652a54c0d451e524c655b1e74bd77b4b7',
                           'installer_item_location': 'apps/VirtualBox-6.1.22__2.dmg',
                           'installer_item_size': 121356,
                           'installs': [{'CFBundleIdentifier': 'org.virtualbox.app.VirtualBox',
                                         'CFBundleName': 'VirtualBox',
                                         'CFBundleShortVersionString': '6.1.22',
                                         'CFBundleVersion': '6.1.22',
                                         'path': '/Applications/VirtualBox.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'minimum_os_version': '10.5.0',
                           'name': 'VirtualBox',
                           'receipts': [{'installed_size': 1193,
                                         'packageid': 'org.virtualbox.pkg.vboxkexts',
                                         'version': '6.1.22'},
                                        {'installed_size': 241536,
                                         'packageid': 'org.virtualbox.pkg.virtualbox',
                                         'version': '6.1.22'},
                                        {'installed_size': 6,
                                         'packageid': 'org.virtualbox.pkg.virtualboxcli',
                                         'version': '6.1.22'},
                                        {'installed_size': 4715,
                                         'packageid': 'com.github.osxfuse.pkg.Core',
                                         'version': '3.10.4'}],
                           'unattended_install': True,
                           'uninstall_method': 'removepackages',
                           'uninstallable': True,
                           'version': '6.1.22'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/VirtualBox-6.1.22__2.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/VirtualBox-6.1.22__2.plist'}}
PathDeleter
{'Input': {'path_list': ['/Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/pkgroot/',
                         '/Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/unpack/']}}
PathDeleter: Deleted /Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/pkgroot/
PathDeleter: Deleted /Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/unpack/
{'Output': {}}
Receipt written to /Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/receipts/VirtualBox.munki-receipt-20210707-120753.plist

The following packages were copied:
    Pkg Path
    --------
    /Users/ben/Library/AutoPkg/Cache/com.github.apizz.munki.VirtualBox/VirtualBox-6.1.22.pkg

The following new items were imported into Munki:
    Name        Version  Catalogs  Pkginfo Path                     Pkg Repo Path                  Icon Repo Path
    ----        -------  --------  ------------                     -------------                  --------------
    VirtualBox  6.1.22   testing   apps/VirtualBox-6.1.22__2.plist  apps/VirtualBox-6.1.22__2.dmg
```