### PR TITLE
Update WacomBamboo.munki.recipe

### DIFF
--- a/Wacom/WacomBamboo.munki.recipe
+++ b/Wacom/WacomBamboo.munki.recipe
@@ -6,39 +6,100 @@
     <string>com.github.apizz.munki.WacomBamboo</string>
     <key>Input</key>
     <dict>
-    <key>MUNKI_CATEGORY</key>
-    <string>Drivers</string>
-    <key>MUNKI_REPO_SUBDIR</key>
-    <string>drivers</string>
-    <key>NAME</key>
-    <string>WacomBamboo</string>
-    <key>pkginfo</key>
-    <dict>
-        <key>catalogs</key>
-        <array>
-        <string>testing</string>
-        </array>
-        <key>category</key>
-        <string>%MUNKI_CATEGORY%</string>
-        <key>description</key>
-        <string>Wacom drivers for the latest professional pen displays and pen tablets, as well as their business solutions.</string>
-        <key>developer</key>
-        <string>Wacom</string>
-        <key>display_name</key>
-        <string>Wacom Bamboo Drivers</string>
-        <key>name</key>
-        <string>%NAME%</string>
-        <key>unattended_install</key>
-        <true/>
-    </dict>
+        <key>DOWNLOAD_URL</key>
+        <string>https://www.wacom.com/en-us/support/product-support/drivers</string>
+        <key>MUNKI_CATEGORY</key>
+        <string>Drivers</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>drivers</string>
+        <key>NAME</key>
+        <string>WacomBamboo</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+            <string>testing</string>
+            </array>
+            <key>category</key>
+            <string>%MUNKI_CATEGORY%</string>
+            <key>description</key>
+            <string>Wacom drivers for the latest professional pen displays and pen tablets, as well as their business solutions.</string>
+            <key>developer</key>
+            <string>Wacom</string>
+            <key>display_name</key>
+            <string>Wacom Bamboo Drivers</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true/>
+        </dict>
     </dict>
     <key>MinimumVersion</key>
     <string>0.5.0</string>
     <key>ParentRecipe</key>
-    <string>com.github.novaksam.pkg.WacomBamboo</string>
+    <string>com.github.novaksam.download.WacomBamboo</string>
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>FlatPkgUnpacker</string>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpack</string>
+                <key>flat_pkg_path</key>
+                <string>%pathname%/*.pkg</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>PkgPayloadUnpacker</string>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                <key>pkg_payload_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpack/content.pkg/Payload</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
+            <key>Arguments</key>
+            <dict>
+                <key>faux_root</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                <key>installs_item_paths</key>
+                <array>
+                    <string>/Library/PreferencePanes/PenTablet.prefPane</string>
+                </array>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>PlistReader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>info_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Library/PreferencePanes/PenTablet.prefPane</string>
+                <key>plist_keys</key>
+                <dict>
+                    <key>CFBundleVersion</key>
+                    <string>version</string>
+                </dict>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
             <key>Arguments</key>
             <dict>
                 <key>additional_pkginfo</key>
@@ -47,10 +108,10 @@
                     <string>%version%</string>
                 </dict>
             </dict>
-            <key>Processor</key>
-            <string>MunkiPkginfoMerger</string>
         </dict>
         <dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>
@@ -58,8 +119,18 @@
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>
+        </dict>
+        <dict>
             <key>Processor</key>
-            <string>MunkiImporter</string>
+            <string>PathDeleter</string>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                    <string>%RECIPE_CACHE_DIR%/unpack</string>
+                </array>
+            </dict>
         </dict>
     </array>
 </dict>


### PR DESCRIPTION
• changed parent to download
• builds an installs_array of the pref pane (like with the other wacom recipe)
• tidies up afters