### PR TITLE
PathDeleter processor not needed

### DIFF
--- a/VLC/VLCUniversal.pkg.recipe
+++ b/VLC/VLCUniversal.pkg.recipe
@@ -28,17 +28,6 @@
             <key>Processor</key>
             <string>AppPkgCreator</string>
         </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>path_list</key>
-                <array>
-                    <string>%RECIPE_CACHE_DIR%/payload</string>
-                </array>
-            </dict>
-            <key>Processor</key>
-            <string>PathDeleter</string>
-        </dict>
     </array>
 </dict>
 </plist>


### PR DESCRIPTION
Remove PathDeleter process since the directory doesn't exist. Thank you for all the recipes!