### PR TITLE
add Installs Array for Crowdstrike Falcon

### DIFF
--- a/CrowdStrike/CrowdStrikeFalcon.munki.recipe
+++ b/CrowdStrike/CrowdStrikeFalcon.munki.recipe
@@ -137,6 +137,8 @@ writelog "*****  Install CrowdStrike Process:  COMPLETE  *****"</string>
             <string>FlatPkgUnpacker</string>
         </dict>
         <dict>
+            <key>Comment</key>
+            <string>Extract and examine the kext version of the app</string>
             <key>Arguments</key>
             <dict>
                 <key>destination_path</key>
@@ -163,6 +165,8 @@ writelog "*****  Install CrowdStrike Process:  COMPLETE  *****"</string>
             <string>CodeSignatureVerifier</string>
         </dict>
         <dict>
+            <key>Comment</key>
+            <string>Remove previously expanded kext version</string>
             <key>Arguments</key>
             <dict>
                 <key>path_list</key>
@@ -174,6 +178,8 @@ writelog "*****  Install CrowdStrike Process:  COMPLETE  *****"</string>
             <string>PathDeleter</string>
         </dict>
         <dict>
+            <key>Comment</key>
+            <string>Extract and examine the system extension version of the app</string>
             <key>Arguments</key>
             <dict>
                 <key>destination_path</key>
@@ -202,6 +208,25 @@ writelog "*****  Install CrowdStrike Process:  COMPLETE  *****"</string>
         <dict>
             <key>Arguments</key>
             <dict>
+                <key>faux_root</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                <key>installs_item_paths</key>
+                <array>
+                    <string>/Applications/Falcon.app</string>
+                </array>
+                <key>version_comparison_key</key>
+                <string>CFBundleShortVersionString</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
                 <key>info_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Falcon.app/Contents/Info.plist</string>
                 <key>plist_keys</key>
@@ -222,25 +247,6 @@ writelog "*****  Install CrowdStrike Process:  COMPLETE  *****"</string>
                     <string>%min_os_version%</string>
                 </dict>
             </dict>
-            <key>Processor</key>
-            <string>MunkiPkginfoMerger</string>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>faux_root</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
-                <key>installs_item_paths</key>
-                <array>
-                    <string>/Applications/Falcon.app</string>
-                </array>
-                <key>version_comparison_key</key>
-                <string>CFBundleShortVersionString</string>
-            </dict>
-            <key>Processor</key>
-            <string>MunkiInstallsItemsCreator</string>
-        </dict>
-        <dict>
             <key>Processor</key>
             <string>MunkiPkginfoMerger</string>
         </dict>

--- a/CrowdStrike/CrowdStrikeFalcon.munki.recipe
+++ b/CrowdStrike/CrowdStrikeFalcon.munki.recipe
@@ -228,6 +228,25 @@ writelog "*****  Install CrowdStrike Process:  COMPLETE  *****"</string>
         <dict>
             <key>Arguments</key>
             <dict>
+                <key>faux_root</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                <key>installs_item_paths</key>
+                <array>
+                    <string>/Applications/Falcon.app</string>
+                </array>
+                <key>version_comparison_key</key>
+                <string>CFBundleShortVersionString</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
                 <key>pkg_path</key>
                 <string>%pathname%</string>
                 <key>repo_subdirectory</key>


### PR DESCRIPTION
Munki will now check that the App itself is installed and not just pkg receipts.

Looks something like this.

```
	<key>installs</key>
	<array>
		<dict>
			<key>CFBundleIdentifier</key>
			<string>com.crowdstrike.falcon.App</string>
			<key>CFBundleName</key>
			<string>Falcon</string>
			<key>CFBundleShortVersionString</key>
			<string>6.30</string>
			<key>CFBundleVersion</key>
			<string>143.01</string>
			<key>minosversion</key>
			<string>10.15</string>
			<key>path</key>
			<string>/Applications/Falcon.app</string>
			<key>type</key>
			<string>application</string>
			<key>version_comparison_key</key>
			<string>CFBundleShortVersionString</string>
		</dict>
	</array>
	
```