### PR TITLE
Remove version merge as variable does not exist

### DIFF
--- a/Ableton/AbletonLive.munki.recipe
+++ b/Ableton/AbletonLive.munki.recipe
@@ -44,18 +44,6 @@ Create in a traditional linear arrangement, or improvise without the constraints
     <string>com.github.jazzace.download.AbletonLive</string>
     <key>Process</key>
     <array>
-    	<dict>
-    		<key>Arguments</key>
-    		<dict>
-    			<key>additional_pkginfo</key>
-    			<dict>
-    				<key>version</key>
-    				<string>%version%</string>
-    			</dict>
-    		</dict>
-    		<key>Processor</key>
-    		<string>MunkiPkginfoMerger</string>
-    	</dict>
         <dict>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
Remove the version merge as the variable "version" is not defined beforehand. 
This results in %version% not being substituted and creating invalid packages