### PR TITLE
Update Suspicious Package minimum macOS version

### DIFF
--- a/Suspicious_Package/SuspiciousPackage.munki.recipe
+++ b/Suspicious_Package/SuspiciousPackage.munki.recipe
@@ -27,7 +27,7 @@
             <key>display_name</key>
             <string>%NAME%</string>
             <key>minimum_os_version</key>
-            <string>10.9.0</string>
+            <string>11</string>
             <key>name</key>
             <string>%NAME%</string>
             <key>unattended_install</key>


### PR DESCRIPTION
As of the latest Suspicious Package release (version 4.3) the [release notes](https://mothersruin.com/software/SuspiciousPackage/relnotes.html) indicate macOS Big Sur is the minimum required version:

> Removed support for macOS 10.15 (Catalina).

This PR updates the Munki recipe to reflect that change.