### PR TITLE
Fix empty pkginfo_repo_path GoogleDrive

### DIFF
--- a/Google_Drive/GoogleDrive.munki.recipe
+++ b/Google_Drive/GoogleDrive.munki.recipe
@@ -81,6 +81,15 @@ If an admin wishes to use this same recipe to manage a single Google Drive PKG i
         <dict>
             <key>Arguments</key>
             <dict>
+                <key>predicate</key>
+                <string>pkginfo_repo_path == ''</string>
+            </dict>
+            <key>Processor</key>
+            <string>StopProcessingIf</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
                 <key>pkginfo_repo_path</key>
                 <string>%pkginfo_repo_path%</string>
             </dict>


### PR DESCRIPTION
If GoogleDrive.munki.recipe is executed but the same App version is already in the munki repo it returns an error that no pkginfo repo path is set:

```
PkgCopier: Mounted disk image /Users/edv/Library/AutoPkg/Cache/local.munki.GoogleDrive/downloads/GoogleDrive.dmg
PkgCopier: Copied /private/tmp/dmg.C36MG7/GoogleDrive.pkg to /Users/edv/Library/AutoPkg/Cache/local.munki.GoogleDrive/GoogleDrive-66.0.3.pkg
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'minimum_os_version': '10.13', 'version': '66.0.3'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Volumes/munki_repo
MunkiImporter: Item GoogleDrive.dmg already exists in the munki repo as pkgs/apps/googledrive/GoogleDrive-66.0.3.dmg.
MunkiOptionalReceiptEditor
You must specify at least one pkginfo repo path
Failed.
Receipt written to /Users/edv/Library/AutoPkg/Cache/local.munki.GoogleDrive/receipts/GoogleDrive-receipt-20221116-164603.plist

The following recipes failed:
    GoogleDrive.munki
        Error in local.munki.GoogleDrive: Processor: MunkiOptionalReceiptEditor: Error: You must specify at least one pkginfo repo path

The following packages were copied:
    Pkg Path                                                                         
    --------                                                                         
    /Users/edv/Library/AutoPkg/Cache/local.munki.GoogleDrive/GoogleDrive-66.0.3.pk
```

With this commit (thanks to [gerardkok](https://github.com/autopkg/gerardkok-recipes/commit/b4c3ef41b414fc515fc6190dca86df20ec0862eb)) it stops the process without an error:
```
PkgCopier: Mounted disk image /Users/edv/Library/AutoPkg/Cache/local.munki.GoogleDrive/downloads/GoogleDrive.dmg
PkgCopier: Copied /private/tmp/dmg.WYnIlq/GoogleDrive.pkg to /Users/edv/Library/AutoPkg/Cache/local.munki.GoogleDrive/GoogleDrive-66.0.3.pkg
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'minimum_os_version': '10.13', 'version': '66.0.3'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Volumes/munki_repo
MunkiImporter: Item GoogleDrive.dmg already exists in the munki repo as pkgs/apps/googledrive/GoogleDrive-66.0.3.dmg.
StopProcessingIf
StopProcessingIf: (pkginfo_repo_path == '') is True
Receipt written to /Users/edv/Library/AutoPkg/Cache/local.munki.GoogleDrive/receipts/GoogleDrive-receipt-20221116-165506.plist

The following packages were copied:
    Pkg Path                                                                         
    --------                                                                         
    /Users/edv/Library/AutoPkg/Cache/local.munki.GoogleDrive/GoogleDrive-66.0.3.pkg 
```