### PR TITLE
TuxeraNTFS

### DIFF
--- a/TuxeraNTFS/TuxeraNTFS.download.recipe
+++ b/TuxeraNTFS/TuxeraNTFS.download.recipe
@@ -20,28 +20,10 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>re_pattern</key>
-                <string>(?P&lt;url&gt;https\:\/\/tuxera\.com\/.*/tuxerantfs_(?P&lt;version&gt;[\d.]+)\.dmg)</string>
-                <key>request_headers</key>
-                <dict>
-                    <key>user-agent</key>
-                    <string>%USER_AGENT%</string>
-                </dict>
-                <key>result_output_var_name</key>
-                <string>version</string>
-                <key>url</key>
-                <string>https://ntfsformac.tuxera.com/support</string>
-            </dict>
-            <key>Processor</key>
-            <string>URLTextSearcher</string>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
                 <key>url</key>
-                <string>%url%</string>
+                <string>https://download.tuxera.com/mac/tuxerantfs_latest.dmg</string>
             </dict>
             <key>Processor</key>
             <string>URLDownloader</string>

--- a/TuxeraNTFS/TuxeraNTFS.munki.recipe
+++ b/TuxeraNTFS/TuxeraNTFS.munki.recipe
@@ -30,8 +30,6 @@
             <string>Tuxera Inc.</string>
             <key>display_name</key>
             <string>Tuxera NTFS</string>
-            <key>minimum_os_version</key>
-            <string>10.4</string>
             <key>name</key>
             <string>%NAME%</string>
             <key>unattended_install</key>
@@ -178,8 +176,8 @@ rm -f /Library/Preferences/com.tuxera.NTFS.plist</string>
             <dict>
                 <key>path_list</key>
                 <array>
-                    <string>%RECIPE_CACHE_DIR%/%NAME%</string>
-                    <string>%RECIPE_CACHE_DIR%/unpack</string>
+                    <string>%RECIPE_CACHE_DIR%/%NAME%/</string>
+                    <string>%RECIPE_CACHE_DIR%/unpack/</string>
                 </array>
             </dict>
             <key>Processor</key>
@@ -188,3 +186,4 @@ rm -f /Library/Preferences/com.tuxera.NTFS.plist</string>
     </array>
 </dict>
 </plist>
+


### PR DESCRIPTION
Hi, @apizz 

This PR updates:

Download
- Removal of URLTextSearcher as there is now a static download URL.

Munki
- Removal of minimum_os_version as there are two ways to set this dynamically within the recipe already.
- updated path list for PathDeleter so the recipe doesn't fail.

Output from a successeful verbose run

```
autopkg run -v /Users/paul/Documents/GitHub/AutoPkg\ Repos/apizz-recipes/TuxeraNTFS/TuxeraNTFS.munki.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/apizz-recipes/TuxeraNTFS/TuxeraNTFS.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/apizz-recipes/TuxeraNTFS/TuxeraNTFS.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/paul/Library/AutoPkg/Cache/com.github.apizz.munki.tuxerantfs/downloads/TuxeraNTFS.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.apizz.munki.tuxerantfs/downloads/TuxeraNTFS.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.Zt6OrI/Install Tuxera NTFS.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.Zt6OrI/Install Tuxera NTFS.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.Zt6OrI/Install Tuxera NTFS.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
AppDmgVersioner
AppDmgVersioner: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.apizz.munki.tuxerantfs/downloads/TuxeraNTFS.dmg
AppDmgVersioner: BundleID: com.tuxera.ntfs_for_mac.installer_launcher
AppDmgVersioner: Version: 2022
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.apizz.munki.tuxerantfs/downloads/TuxeraNTFS.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Install Tuxera NTFS.mpkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Tuxera Inc. (PPNVCC9Z68)
CodeSignatureVerifier:        Expires: 2026-08-31 08:52:27 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            E8 E9 67 EF 2A FD CC E1 91 BD 8B DA FB 63 00 DD 4C E3 60 95 2D 81 
CodeSignatureVerifier:            5E D7 52 C6 B4 16 E4 27 37 9E
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
Copier
Copier: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.apizz.munki.tuxerantfs/downloads/TuxeraNTFS.dmg
Copier: Copied /private/tmp/dmg.HElagd/Install Tuxera NTFS.app/Contents/Resources/Packages/Flat/Install Tuxera NTFS.mpkg to /Users/paul/Library/AutoPkg/Cache/com.github.apizz.munki.tuxerantfs/TuxeraNTFS.mpkg
FlatPkgUnpacker
FlatPkgUnpacker: Unpacked /Users/paul/Library/AutoPkg/Cache/com.github.apizz.munki.tuxerantfs/TuxeraNTFS.mpkg to /Users/paul/Library/AutoPkg/Cache/com.github.apizz.munki.tuxerantfs/unpack
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked /Users/paul/Library/AutoPkg/Cache/com.github.apizz.munki.tuxerantfs/unpack/TuxeraNTFS.pkg/Payload to /Users/paul/Library/AutoPkg/Cache/com.github.apizz.munki.tuxerantfs/TuxeraNTFS
CodeSignatureVerifier
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.apizz.munki.tuxerantfs/TuxeraNTFS/Applications/Tuxera Disk Manager.app: valid on disk
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.apizz.munki.tuxerantfs/TuxeraNTFS/Applications/Tuxera Disk Manager.app: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.apizz.munki.tuxerantfs/TuxeraNTFS/Applications/Tuxera Disk Manager.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
PlistReader
PlistReader: Reading: /Users/paul/Library/AutoPkg/Cache/com.github.apizz.munki.tuxerantfs/TuxeraNTFS/Applications/Tuxera Disk Manager.app/Contents/Info.plist
PlistReader: Assigning value of '2022' to output variable 'version'
PlistReader: Assigning value of '10.4' to output variable 'min_os_version'
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'minimum_os_version': '10.4', 'version': '2022'} into pkginfo
CodeSignatureVerifier
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.apizz.munki.tuxerantfs/TuxeraNTFS/Library/PreferencePanes/Tuxera NTFS.prefPane: valid on disk
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.apizz.munki.tuxerantfs/TuxeraNTFS/Library/PreferencePanes/Tuxera NTFS.prefPane: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.apizz.munki.tuxerantfs/TuxeraNTFS/Library/PreferencePanes/Tuxera NTFS.prefPane: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/Tuxera Disk Manager.app
MunkiInstallsItemsCreator: Created installs item for /Library/PreferencePanes/Tuxera NTFS.prefPane
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'minimum_os_version': '10.4', 'version': '2022', 'installs': [{'CFBundleIdentifier': 'com.tuxera.TuxeraDiskManager', 'CFBundleName': 'Tuxera Disk Manager', 'CFBundleShortVersionString': '2022', 'CFBundleVersion': '2022.0.0', 'minosversion': '10.4', 'path': '/Applications/Tuxera Disk Manager.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}, {'CFBundleShortVersionString': '2022', 'CFBundleVersion': '2022.0.0', 'path': '/Library/PreferencePanes/Tuxera NTFS.prefPane', 'type': 'bundle', 'version_comparison_key': 'CFBundleShortVersionString'}]} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/tuxerantfs/TuxeraNTFS-2022__1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/tuxerantfs/TuxeraNTFS-2022__1.mpkg
PathDeleter
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.apizz.munki.tuxerantfs/TuxeraNTFS/
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.apizz.munki.tuxerantfs/unpack/
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.apizz.munki.tuxerantfs/receipts/TuxeraNTFS.munki-receipt-20221213-154915.plist

The following new items were imported into Munki:
    Name        Version  Catalogs  Pkginfo Path                              Pkg Repo Path                            Icon Repo Path  
    ----        -------  --------  ------------                              -------------                            --------------  
    TuxeraNTFS  2022     testing   apps/tuxerantfs/TuxeraNTFS-2022__1.plist  apps/tuxerantfs/TuxeraNTFS-2022__1.mpkg
```