### PR TITLE
Update DigiExamClient.download.recipe

### DIFF
--- a/DigiExam/DigiExamClient.download.recipe
+++ b/DigiExam/DigiExamClient.download.recipe
@@ -21,7 +21,7 @@
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
                 <key>url</key>
-                <string>https://www.digiexam.com/hubfs/client/DigiExam_Mac.dmg</string>
+                <string>https://www.digiexam.com/hubfs/client/Digiexam_Mac.dmg</string>
             </dict>
             <key>Processor</key>
             <string>URLDownloader</string>


### PR DESCRIPTION
Hi, @apizz 

This PR has an updated download URL. 

Output from a successdful -vv run

```
autopkg run -vv /Users/paul/Documents/GitHub/AutoPkg\ Repos/apizz-recipes/DigiExam/DigiExamClient.munki.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/apizz-recipes/DigiExam/DigiExamClient.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/apizz-recipes/DigiExam/DigiExamClient.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'DigiExam.dmg',
           'url': 'https://www.digiexam.com/hubfs/client/DigiExam_Mac.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
Command '['/usr/bin/curl', '--silent', '--show-error', '--no-buffer', '--dump-header', '-', '--speed-time', '30', '--location', '--url', 'https://www.digiexam.com/hubfs/client/DigiExam_Mac.dmg', '--fail', '--output', '/Users/paul/Library/AutoPkg/Cache/com.github.apizz.munki.DigiExam/downloads/tmpk3d0zpua']' returned non-zero exit status 22.
Failed.
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.apizz.munki.DigiExam/receipts/DigiExamClient.munki-receipt-20230704-111115.plist

The following recipes failed:
    /Users/paul/Documents/GitHub/AutoPkg Repos/apizz-recipes/DigiExam/DigiExamClient.munki.recipe
        Error in com.github.apizz.munki.DigiExam: Processor: URLDownloader: Error: Command '['/usr/bin/curl', '--silent', '--show-error', '--no-buffer', '--dump-header', '-', '--speed-time', '30', '--location', '--url', 'https://www.digiexam.com/hubfs/client/DigiExam_Mac.dmg', '--fail', '--output', '/Users/paul/Library/AutoPkg/Cache/com.github.apizz.munki.DigiExam/downloads/tmpk3d0zpua']' returned non-zero exit status 22.

Nothing downloaded, packaged or imported.
paul@paul-HD2RNVWDGY ~ % autopkg run -vv /Users/paul/Documents/GitHub/AutoPkg\ Repos/apizz-recipes/DigiExam/DigiExamClient.munki.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/apizz-recipes/DigiExam/DigiExamClient.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/apizz-recipes/DigiExam/DigiExamClient.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'DigiExam.dmg',
           'url': 'https://www.digiexam.com/hubfs/client/Digiexam_Mac.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 27 Jun 2023 12:47:28 GMT
URLDownloader: Storing new ETag header: "fce5fc39d15974527a0e017415a21e33"
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/com.github.apizz.munki.DigiExam/downloads/DigiExam.dmg
{'Output': {'download_changed': True,
            'etag': '"fce5fc39d15974527a0e017415a21e33"',
            'last_modified': 'Tue, 27 Jun 2023 12:47:28 GMT',
            'pathname': '/Users/paul/Library/AutoPkg/Cache/com.github.apizz.munki.DigiExam/downloads/DigiExam.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/paul/Library/AutoPkg/Cache/com.github.apizz.munki.DigiExam/downloads/DigiExam.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/paul/Library/AutoPkg/Cache/com.github.apizz.munki.DigiExam/downloads/DigiExam.dmg/DigiExam.app',
           'requirement': 'identifier "se.digiexam.DigiExam" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"73T9H7VE4P"',
           'strict_verification': True}}
CodeSignatureVerifier: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.apizz.munki.DigiExam/downloads/DigiExam.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /private/tmp/dmg.egRrl9/DigiExam.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.egRrl9/DigiExam.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.egRrl9/DigiExam.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
PlistReader
{'Input': {'info_path': '/Users/paul/Library/AutoPkg/Cache/com.github.apizz.munki.DigiExam/downloads/DigiExam.dmg/DigiExam.app/Contents/Info.plist',
           'plist_keys': {'CFBundleShortVersionString': 'version',
                          'LSMinimumSystemVersion': 'min_os_version'}}}
PlistReader: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.apizz.munki.DigiExam/downloads/DigiExam.dmg
PlistReader: Reading: /private/tmp/dmg.7rS4eB/DigiExam.app/Contents/Info.plist
PlistReader: Assigning value of '14.1.0' to output variable 'version'
PlistReader: Assigning value of '10.10' to output variable 'min_os_version'
{'Output': {'plist_reader_output_variables': {'min_os_version': '10.10',
                                              'version': '14.1.0'}}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '/Users/paul/Library/AutoPkg/Cache/com.github.apizz.munki.DigiExam/downloads/DigiExam.dmg',
           'pkginfo': {'catalogs': ['testing'],
                       'category': 'Testing',
                       'description': 'DigiExam is used by universities and '
                                      'schools to create, distribute, grade '
                                      'and publish high-stakes exams and '
                                      'academic tests.',
                       'developer': 'DigiExam',
                       'display_name': 'DigiExam Client',
                       'name': 'DigiExam',
                       'unattended_install': True},
           'repo_subdirectory': 'apps/digiexam'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/digiexam/DigiExam-14.1.0.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/digiexam/DigiExam-14.1.0.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'DigiExam',
                                                       'pkg_repo_path': 'apps/digiexam/DigiExam-14.1.0.dmg',
                                                       'pkginfo_path': 'apps/digiexam/DigiExam-14.1.0.plist',
                                                       'version': '14.1.0'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'paul',
                                         'creation_date': datetime.datetime(2023, 7, 4, 10, 14, 49),
                                         'munki_version': '5.5.1.4365',
                                         'os_version': '13.4.1'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'category': 'Testing',
                           'description': 'DigiExam is used by universities '
                                          'and schools to create, distribute, '
                                          'grade and publish high-stakes exams '
                                          'and academic tests.',
                           'developer': 'DigiExam',
                           'display_name': 'DigiExam Client',
                           'installer_item_hash': 'f28fc66ab54af932ce50f23ec1e6b6a025f3e689ea2fed4af07f0be0720a0295',
                           'installer_item_location': 'apps/digiexam/DigiExam-14.1.0.dmg',
                           'installer_item_size': 89659,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'se.digiexam.DigiExam',
                                         'CFBundleName': 'Digiexam',
                                         'CFBundleShortVersionString': '14.1.0',
                                         'CFBundleVersion': '14.1.0',
                                         'minosversion': '10.10',
                                         'path': '/Applications/Digiexam.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'items_to_copy': [{'destination_path': '/Applications',
                                              'source_item': 'Digiexam.app'}],
                           'minimum_os_version': '10.10',
                           'name': 'DigiExam',
                           'unattended_install': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '14.1.0'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/digiexam/DigiExam-14.1.0.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/digiexam/DigiExam-14.1.0.plist'}}
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.apizz.munki.DigiExam/receipts/DigiExamClient.munki-receipt-20230704-111449.plist

The following new items were downloaded:
    Download Path                                                                             
    -------------                                                                             
    /Users/paul/Library/AutoPkg/Cache/com.github.apizz.munki.DigiExam/downloads/DigiExam.dmg  

The following new items were imported into Munki:
    Name      Version  Catalogs  Pkginfo Path                         Pkg Repo Path                      Icon Repo Path  
    ----      -------  --------  ------------                         -------------                      --------------  
    DigiExam  14.1.0   testing   apps/digiexam/DigiExam-14.1.0.plist  apps/digiexam/DigiExam-14.1.0.dmg
```