### PR TITLE
Update FileMakerProClaris.download.recipe

### DIFF
--- a/FileMaker/FileMakerProClaris.download.recipe
+++ b/FileMaker/FileMakerProClaris.download.recipe
@@ -15,7 +15,7 @@ To use this recipe, go to https://www.filemaker.com/redirects/ss.txt and find th
         <key>NAME</key>
         <string>FileMakerPro</string>
         <key>SEARCH_PATTERN</key>
-        <string>("%PRODUCT_ID%","url":"(?P&lt;url&gt;https://downloads.claris.com/esd/fmp_(?P&lt;version&gt;[\d.]+).dmg)")</string>
+        <string>("%PRODUCT_ID%","url":"(?P&lt;url&gt;https://downloads\.claris\.com/[esdTBU\d/]+/fm[sp_trial]+(?P&lt;version&gt;[\d.]+)\.dmg)")</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.6.1</string>


### PR DESCRIPTION
Improve the default regex to allow download of Server as well as supporting both versions 19 and 20 (which have slightly different download path structures). Also, escape all the dots outside of [] to ensure literal match.