### PR TITLE
Update FileMakerProClaris.download.recipe to support v. 20

### DIFF
--- a/FileMaker/FileMakerProClaris.download.recipe
+++ b/FileMaker/FileMakerProClaris.download.recipe
@@ -15,7 +15,7 @@ To use this recipe, go to https://www.filemaker.com/redirects/ss.txt and find th
         <key>NAME</key>
         <string>FileMakerPro</string>
         <key>SEARCH_PATTERN</key>
-        <string>("%PRODUCT_ID%","url":"(?P&lt;url&gt;https://downloads.claris.com/esd/fmp_(?P&lt;version&gt;[\d.]+).dmg)")</string>
+        <string>("%PRODUCT_ID%","url":"(?P&lt;url&gt;https://downloads.claris.com/[esdTBU\d/]+fmp_(?P&lt;version&gt;[\d.]+).dmg)")</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.6.1</string>


### PR DESCRIPTION
The download URL path structure has changed. This updates the default regex to support at least versions 19 and 20.