### PR TITLE
Update Timing.download.recipe

### DIFF
--- a/Timing/Timing.download.recipe
+++ b/Timing/Timing.download.recipe
@@ -21,7 +21,7 @@
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
                 <key>url</key>
-                <string>https://timingapp.com/download/Timing.dmg</string>
+                <string>https://downloads.timingapp.com/Timing.dmg</string>
             </dict>
             <key>Processor</key>
             <string>URLDownloader</string>


### PR DESCRIPTION
Timing is using the link currently in this recipe for their release candidates, not sure when this behaviour changed.

The download link on their website is now https://downloads.timingapp.com/Timing.dmg