### PR TITLE
Update FileMakerProClaris.download.recipe

### DIFF
--- a/FileMaker/FileMakerProClaris.download.recipe
+++ b/FileMaker/FileMakerProClaris.download.recipe
@@ -15,7 +15,7 @@ To use this recipe, go to https://www.filemaker.com/redirects/ss.txt and find th
         <key>NAME</key>
         <string>FileMakerPro</string>
         <key>SEARCH_PATTERN</key>
-        <string>("%PRODUCT_ID%","url":"(?P&lt;url&gt;https://downloads.claris.com/[esdTBU\d/]+fmp_(?P&lt;version&gt;[\d.]+).dmg)")</string>
+        <string>("%PRODUCT_ID%","url":"(?P&lt;url&gt;https://.*fmp.*_(?P&lt;version&gt;[\d.]+).dmg)")</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.6.1</string>


### PR DESCRIPTION
Simplified search pattern that can now match older versions with the old filemaker.com download links, advanced versions and trials.  Without this specifying older versions such as PROADV17MAC would just result in an error even though they has valid entries in https://www.filemaker.com/redirects/ss.txt.