### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/OpenKiosk/OpenKiosk.download.recipe
+++ b/OpenKiosk/OpenKiosk.download.recipe
@@ -21,7 +21,7 @@
 				<key>re_pattern</key>
 				<string>(?P&lt;url&gt;https\:\/\/www\.mozdevgroup.com\/.*\/openkiosk-(?P&lt;version&gt;[\d.]+)-(?P&lt;date&gt;[\d-]+)\.dmg)</string>
 				<key>url</key>
-				<string>http://openkiosk.mozdevgroup.com/</string>
+				<string>https://openkiosk.mozdevgroup.com/</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [in January 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso).

Thanks for considering!