### PR TITLE
Update TailScale.pkg.recipe

### DIFF
--- a/TailScale/TailScale.pkg.recipe
+++ b/TailScale/TailScale.pkg.recipe
@@ -30,7 +30,7 @@
             <key>Arguments</key>
             <dict>
                 <key>info_path</key>
-                <string>%pathname%/Tailscale.app/Contents/Info.plist</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Tailscale.app/Contents/Info.plist</string>
                 <key>plist_keys</key>
                 <dict>
                     <key>CFBundleShortVersionString</key>


### PR DESCRIPTION
Fixed pathing error in the PlistReader processor.

When running the recipe as-is, the error is 
`Error in com.github.apizz.pkg.TailScale: Processor: PlistReader: Error: Path '/Users/eholtam/Library/AutoPkg/Cache/com.github.apizz.pkg.TailScale/downloads/Tailscale.zip/Tailscale.app/Contents/Info.plist' doesn't exist!`

It is trying to reference the Info.plist thru the .zip archive and failing.
Changing the path to the cache folder and downloaded app fixes this.