### PR TITLE
Tart

### DIFF
--- a/Tart/Tart.munki.recipe
+++ b/Tart/Tart.munki.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest version of Tart and imports it into a munki_repo.</string>
+    <string>Downloads the latest version of Tart and imports it into a munki_repo. Specify an ARCH of "arm64" for Apple Silicon or "amd64" for Intel.</string>
     <key>Identifier</key>
     <string>com.github.apizz.munki.Tart</string>
     <key>Input</key>
@@ -11,9 +11,11 @@
         <key>MUNKI_CATEGORY</key>
         <string>Virtualization</string>
         <key>MUNKI_REPO_SUBDIR</key>
-        <string>cli-tools/tart</string>
+        <string>cli-tools/tart/%ARCH%</string>
         <key>NAME</key>
         <string>Tart</string>
+        <key>ARCH</key>
+        <string>arm64</string>
         <key>pkginfo</key>
         <dict>
             <key>catalogs</key>
@@ -32,10 +34,6 @@
             <string>12.0</string>
             <key>name</key>
             <string>%NAME%</string>
-            <key>supported_architectures</key>
-            <array>
-                <string>arm64</string>
-            </array>
             <key>unattended_install</key>
             <true/>
         </dict>
@@ -46,6 +44,33 @@
     <string>com.github.wegotoeleven-recipes.pkg.Tart</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>find</key>
+                <string>amd64</string>
+                <key>input_string</key>
+                <string>%ARCH%</string>
+                <key>replace</key>
+                <string>x86_64</string>
+            </dict>
+            <key>Processor</key>
+            <string>com.github.homebysix.FindAndReplace/FindAndReplace</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>supported_architectures</key>
+                    <array>
+                        <string>%output_string%</string>
+                    </array>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
         <dict>
             <key>Arguments</key>
             <dict>

--- a/Tart/Tart.munki.recipe
+++ b/Tart/Tart.munki.recipe
@@ -50,7 +50,7 @@
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>
-                <string>%pathname%</string>
+                <string>%pkg_path%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>


### PR DESCRIPTION
This PR has two commits:

1. Fixes MunkiImporter to grab the package and not the downloaded archive to prevent this error:

```
The following recipes failed:
    com.github.apizz.munki.Tart
        Error in com.github.apizz.munki.Tart: Processor: MunkiImporter: Error: creating pkginfo for
~/Library/AutoPkg/Cache/com.github.apizz.munki.Tart/downloads/tart-arm64.tar.gz failed:
~/Library/AutoPkg/Cache/com.github.apizz.munki.Tart/downloads/tart-arm64.tar.gz is not a valid installer item!
```

2. This commit adds architecture support to match the parent recipe: https://github.com/autopkg/wegotoeleven-recipes/pull/4