### PR TITLE
Enable Enterprise Mode for Wacom Tablet installations

### DIFF
--- a/Wacom/WacomTablet.munki.recipe
+++ b/Wacom/WacomTablet.munki.recipe
@@ -57,7 +57,18 @@ fi
 
 if [ -d "$APP" ]; then
     sudo "$EXE" --uninstall
-fi</string>
+fi
+
+# Set "Enterprise Mode" for version 6.4.4 and later
+# Source: https://community.jamf.com/t5/jamf-pro/how-to-disable-auto-launching-quot-wacom-desktop-center-quot-app/m-p/322943#M278338
+cat &lt;&lt; EOF &gt; "/Library/Preferences/com.wacomtablet.defaults.xml"
+&lt;?xml version="1.0" encoding="utf-8"?&gt;
+&lt;root&gt;
+  &lt;OperatingMode&gt;Enterprise&lt;/OperatingMode&gt;
+&lt;/root&gt;
+EOF
+
+exit 0</string>
             <key>unattended_install</key>
             <true/>
         </dict>


### PR DESCRIPTION
Since version 6.4.4, Wacom has included an "Enterprise Mode" feature that enables some configurations useful for Mac admins, most notably the suppression of the automatic app launch behavior previously seen during installations or upgrades. This represents a huge improvement in user experience, and helps avoid unexpected disruptions caused by background installations or updates.

Credit to kacey3 on Jamf Nation for discovering this XML option: https://community.jamf.com/t5/jamf-pro/how-to-disable-auto-launching-quot-wacom-desktop-center-quot-app/m-p/324051/highlight/true#M278694