### PR TITLE
Consolidate Code42 recipes into a single set that supports multiple architectures

### DIFF
--- a/Code42/Code42-arm64.download.recipe
+++ b/Code42/Code42-arm64.download.recipe
@@ -16,6 +16,15 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>The Code42 recipes in this repo have been combined. Use the ARCH input variable to specify "arm64" as the desired architecture in your override. The standalone Code42-arm64 recipes will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>filename</key>

--- a/Code42/Code42.download.recipe
+++ b/Code42/Code42.download.recipe
@@ -3,25 +3,45 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest Intel-based version of Code42.</string>
+    <string>Downloads the latest version of Code42.
+    
+Provide the desired architecture in the ARCH variable. Options include:
+- "x86_64" (default, downloads the Intel-based version)
+- "arm64" (downloads the arm64 version)
+</string>
     <key>Identifier</key>
     <string>com.github.apizz.download.Code42</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
         <string>Code42</string>
+        <key>ARCH</key>
+        <string>x86_64</string>
     </dict>
     <key>MinimumVersion</key>
     <string>1.1.0</string>
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>com.github.homebysix.FindAndReplace/FindAndReplace</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_string</key>
+                <string>https://download-preservation.code42.com/installs/agent/latest-mac-%ARCH%.dmg</string>
+                <key>find</key>
+                <string>-x86_64</string>
+                <key>replace</key>
+                <string></string>
+            </dict>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
                 <key>url</key>
-                <string>https://download-preservation.code42.com/installs/agent/latest-mac.dmg</string>
+                <string>%output_string%</string>
             </dict>
             <key>Processor</key>
             <string>URLDownloader</string>

--- a/Code42/Code42.munki.recipe
+++ b/Code42/Code42.munki.recipe
@@ -3,7 +3,12 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest Intel-based version of Code42 and imports it into a munki_repo.</string>
+    <string>Downloads the latest version of Code42 and imports it into a munki_repo.
+    
+Provide the desired architecture in the ARCH variable. Options include:
+- "x86_64" (default, downloads the Intel-based version)
+- "arm64" (downloads the arm64 version)
+</string>
     <key>Identifier</key>
     <string>com.github.apizz.munki.Code42</string>
     <key>Input</key>
@@ -43,7 +48,7 @@
             <string>%NAME%</string>
             <key>supported_architectures</key>
             <array>
-                <string>x86_64</string>
+                <string>%ARCH%</string>
             </array>
             <key>uninstall_method</key>
             <string>uninstall_script</string>

--- a/Code42/Code42.pkg.recipe
+++ b/Code42/Code42.pkg.recipe
@@ -3,7 +3,12 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest Intel-based version of Code42 and extracts the installer PKG.</string>
+    <string>Downloads the latest version of Code42 and extracts the installer PKG.
+    
+Provide the desired architecture in the ARCH variable. Options include:
+- "x86_64" (default, downloads the Intel-based version)
+- "arm64" (downloads the arm64 version)
+</string>
     <key>Identifier</key>
     <string>com.github.apizz.pkg.Code42</string>
     <key>Input</key>


### PR DESCRIPTION
New recipe run output with default `ARCH` value (x86_64):

```
% autopkg run -vv 'apizz-recipes/Code42/Code42.download.recipe'
Processing apizz-recipes/Code42/Code42.download.recipe...
WARNING: apizz-recipes/Code42/Code42.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
com.github.homebysix.FindAndReplace/FindAndReplace
{'Input': {'find': '-x86_64',
           'input_string': 'https://download-preservation.code42.com/installs/agent/latest-mac-x86_64.dmg',
           'replace': ''}}
FindAndReplace: Replacing "-x86_64" with "" in "https://download-preservation.code42.com/installs/agent/latest-mac-x86_64.dmg".
{'Output': {'output_string': 'https://download-preservation.code42.com/installs/agent/latest-mac.dmg'}}
URLDownloader
{'Input': {'filename': 'Code42.dmg',
           'url': 'https://download-preservation.code42.com/installs/agent/latest-mac.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 11 Sep 2024 19:16:19 GMT
URLDownloader: Storing new ETag header: "1911f48286d0a0c33c86ef9c3afc06aa-28"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/downloads/Code42.dmg
{'Output': {'download_changed': True,
            'etag': '"1911f48286d0a0c33c86ef9c3afc06aa-28"',
            'last_modified': 'Wed, 11 Sep 2024 19:16:19 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/downloads/Code42.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/downloads/Code42.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Code 42 '
                                        'Software (9YV9435DHD)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/downloads/Code42.dmg/Install '
                         'Code42.pkg'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/downloads/Code42.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Install Code42.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2024-09-10 21:31:47 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Code 42 Software (9YV9435DHD)
CodeSignatureVerifier:        Expires: 2027-02-01 15:44:57 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            60 BD F2 D6 13 6E BF 50 F5 E5 DF 33 BB C0 54 05 80 9E 74 CE 92 F1 
CodeSignatureVerifier:            26 E9 D5 4C 87 9E A5 57 DA CE
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2031-09-17 00:00:00 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            F1 6C D3 C5 4C 7F 83 CE A4 BF 1A 3E 6A 08 19 C8 AA A8 E4 A1 52 8F 
CodeSignatureVerifier:            D1 44 71 5F 35 06 43 D2 DF 3A
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
FlatPkgUnpacker
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/unpack',
           'flat_pkg_path': '~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/downloads/Code42.dmg/Install '
                            'Code42.pkg'}}
FlatPkgUnpacker: Mounted disk image ~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/downloads/Code42.dmg
FlatPkgUnpacker: Unpacked /private/tmp/dmg.nuEVPf/Install Code42.pkg to ~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/unpack
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/Code42/Applications',
           'pkg_payload_path': '~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/unpack/code42.pkg/Payload'}}
PkgPayloadUnpacker: Unpacked ~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/unpack/code42.pkg/Payload to ~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/Code42/Applications
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': [],
           'input_path': '~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/Code42/Applications/Code42.app',
           'requirement': 'identifier "com.backup42.desktop" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"9YV9435DHD"',
           'strict_verification': True}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/Code42/Applications/Code42.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/Code42/Applications/Code42.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/Code42/Applications/Code42.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
PlistReader
{'Input': {'info_path': '~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/Code42/Applications/Code42.app/Contents/Info.plist',
           'plist_keys': {'CFBundleShortVersionString': 'version'}}}
PlistReader: Reading: ~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/Code42/Applications/Code42.app/Contents/Info.plist
PlistReader: Assigning value of '12.5.0' to output variable 'version'
{'Output': {'plist_reader_output_variables': {'version': '12.5.0'}}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/receipts/Code42.download-receipt-20241222-125119.plist

The following new items were downloaded:
    Download Path                                                                              
    -------------                                                                              
    ~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/downloads/Code42.dmg  
```

New recipe run output with Apple Silicon `ARCH` value (arm64):

```
% autopkg run -vv 'apizz-recipes/Code42/Code42.download.recipe' -k ARCH=ar
m64
Processing apizz-recipes/Code42/Code42.download.recipe...
WARNING: apizz-recipes/Code42/Code42.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
com.github.homebysix.FindAndReplace/FindAndReplace
{'Input': {'find': '-x86_64',
           'input_string': 'https://download-preservation.code42.com/installs/agent/latest-mac-arm64.dmg',
           'replace': ''}}
FindAndReplace: Replacing "-x86_64" with "" in "https://download-preservation.code42.com/installs/agent/latest-mac-arm64.dmg".
{'Output': {'output_string': 'https://download-preservation.code42.com/installs/agent/latest-mac-arm64.dmg'}}
URLDownloader
{'Input': {'filename': 'Code42.dmg',
           'url': 'https://download-preservation.code42.com/installs/agent/latest-mac-arm64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 11 Sep 2024 19:16:19 GMT
URLDownloader: Storing new ETag header: "205ae7078d0542e3b631dc562079f7be-27"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/downloads/Code42.dmg
{'Output': {'download_changed': True,
            'etag': '"205ae7078d0542e3b631dc562079f7be-27"',
            'last_modified': 'Wed, 11 Sep 2024 19:16:19 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/downloads/Code42.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/downloads/Code42.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Code 42 '
                                        'Software (9YV9435DHD)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/downloads/Code42.dmg/Install '
                         'Code42.pkg'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/downloads/Code42.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Install Code42.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2024-09-10 21:31:47 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Code 42 Software (9YV9435DHD)
CodeSignatureVerifier:        Expires: 2027-02-01 15:44:57 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            60 BD F2 D6 13 6E BF 50 F5 E5 DF 33 BB C0 54 05 80 9E 74 CE 92 F1 
CodeSignatureVerifier:            26 E9 D5 4C 87 9E A5 57 DA CE
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2031-09-17 00:00:00 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            F1 6C D3 C5 4C 7F 83 CE A4 BF 1A 3E 6A 08 19 C8 AA A8 E4 A1 52 8F 
CodeSignatureVerifier:            D1 44 71 5F 35 06 43 D2 DF 3A
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
FlatPkgUnpacker
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/unpack',
           'flat_pkg_path': '~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/downloads/Code42.dmg/Install '
                            'Code42.pkg'}}
FlatPkgUnpacker: Mounted disk image ~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/downloads/Code42.dmg
FlatPkgUnpacker: Unpacked /private/tmp/dmg.ZFepvJ/Install Code42.pkg to ~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/unpack
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/Code42/Applications',
           'pkg_payload_path': '~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/unpack/code42.pkg/Payload'}}
PkgPayloadUnpacker: Unpacked ~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/unpack/code42.pkg/Payload to ~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/Code42/Applications
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': [],
           'input_path': '~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/Code42/Applications/Code42.app',
           'requirement': 'identifier "com.backup42.desktop" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"9YV9435DHD"',
           'strict_verification': True}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/Code42/Applications/Code42.app: a sealed resource is missing or invalid
CodeSignatureVerifier: In subcomponent: ~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/Code42/Applications/Code42.app/Contents/Frameworks/Electron Framework.framework
CodeSignatureVerifier: file added: ~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/Code42/Applications/Code42.app/Contents/Frameworks/Electron Framework.framework/Versions/Current/Resources/v8_context_snapshot.x86_64.bin
Code signature verification failed. Note that all verifications can be disabled by setting the variable DISABLE_CODE_SIGNATURE_VERIFICATION to a non-empty value.
Failed.
Receipt written to ~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/receipts/Code42.download-receipt-20241222-125143.plist

The following recipes failed:
    apizz-recipes/Code42/Code42.download.recipe
        Error in com.github.apizz.download.Code42: Processor: CodeSignatureVerifier: Error: Code signature verification failed. Note that all verifications can be disabled by setting the variable DISABLE_CODE_SIGNATURE_VERIFICATION to a non-empty value.

The following new items were downloaded:
    Download Path                                                                              
    -------------                                                                              
    ~/Library/AutoPkg/Cache/com.github.apizz.download.Code42/downloads/Code42.dmg
```