### PR TITLE
Update ProfileCreator.munki.recipe

### DIFF
--- a/ProfileCreator/ProfileCreator.munki.recipe
+++ b/ProfileCreator/ProfileCreator.munki.recipe
@@ -42,35 +42,13 @@
     <array>
         <dict>
             <key>Processor</key>
-            <string>DmgCreator</string>
-            <key>Arguments</key>
-            <dict>
-                <key>dmg_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-                <key>dmg_root</key>
-                <string>%RECIPE_CACHE_DIR%/Applications</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
             <string>MunkiImporter</string>
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>
-                <string>%dmg_path%</string>
+                <string>%pathname%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PathDeleter</string>
-            <key>Arguments</key>
-            <dict>
-                <key>path_list</key>
-                <array>
-                    <string>%RECIPE_CACHE_DIR%/Applications</string>
-                </array>
             </dict>
         </dict>
     </array>


### PR DESCRIPTION
Hi, @apizz 

Profile Creator has a new release but the file format has changed from a zip to a dmg. This PR is based on changes to the download in this PR https://github.com/autopkg/neilmartin83-recipes/pull/24

Output from a successful -v run
```
autopkg run -v ProfileCreator.munki.recipe
Looking for com.github.neilmartin83.download.ProfileCreator...
Did not find com.github.neilmartin83.download.ProfileCreator in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.neilmartin83.download.ProfileCreator...
Found com.github.neilmartin83.download.ProfileCreator in recipe map
**load_recipe time: 0.006694916010019369
Processing ProfileCreator.munki.recipe...
WARNING: ProfileCreator.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
GitHubReleasesInfoProvider: Selected asset 'ProfileCreator-0.3.6.dmg' from tag '0.3.6' at url https://github.com/ProfileCreator/ProfileCreator/releases/download/0.3.6/ProfileCreator-0.3.6.dmg
URLDownloader
URLDownloader: Storing new Last-Modified header: Mon, 23 Dec 2024 23:41:21 GMT
URLDownloader: Storing new ETag header: "0x8DD23AB4E367CA5"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.ProfileCreator/downloads/ProfileCreator-0.3.6.dmg
EndOfCheckPhase
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/profilecreator/ProfileCreator-0.3.6.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/profilecreator/ProfileCreator-0.3.6.dmg
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.ProfileCreator/receipts/ProfileCreator.munki-receipt-20241224-130542.plist

The following new items were downloaded:
    Download Path                                                                                                      
    -------------                                                                                                      
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.ProfileCreator/downloads/ProfileCreator-0.3.6.dmg  

The following new items were imported into Munki:
    Name            Version  Catalogs  Pkginfo Path                                    Pkg Repo Path                                 Icon Repo Path  
    ----            -------  --------  ------------                                    -------------                                 --------------  
    ProfileCreator  0.3.6    testing   apps/profilecreator/ProfileCreator-0.3.6.plist  apps/profilecreator/ProfileCreator-0.3.6.dmg
```