### PR TITLE
Add user-agent to Dragonframe License Manager download

### DIFF
--- a/Dragonframe/DragonframeLicenseServer.download.recipe
+++ b/Dragonframe/DragonframeLicenseServer.download.recipe
@@ -20,6 +20,11 @@
                 <string>(\/download\/DragonframeLicenseManager_(?P&lt;version&gt;[\d\.]+)\.pkg)</string>
                 <key>url</key>
                 <string>https://www.dragonframe.com/downloads/</string>
+                <key>request_headers</key>
+                <dict>
+                    <key>user-agent</key>
+                    <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36</string>
+                </dict>
             </dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>
@@ -28,7 +33,7 @@
             <key>Arguments</key>
             <dict>
                 <key>filename</key>
-                <string>%NAME%.pkg</string>
+                <string>%NAME%-%version%.pkg</string>
                 <key>url</key>
                 <string>https://www.dragonframe.com%match%</string>
             </dict>


### PR DESCRIPTION
The /download page now seems to require a user-agent.

Verbose recipe run:

```
% autopkg run -vvq 'Dragonframe/DragonframeLicenseServer.download.recipe'
Processing Dragonframe/DragonframeLicenseServer.download.recipe...
WARNING: Dragonframe/DragonframeLicenseServer.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '(\\/download\\/DragonframeLicenseManager_(?P<version>[\\d\\.]+)\\.pkg)',
           'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_15_7) '
                                             'AppleWebKit/537.36 (KHTML, like '
                                             'Gecko) Chrome/131.0.0.0 '
                                             'Safari/537.36'},
           'url': 'https://www.dragonframe.com/downloads/'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (version): 3.0.0
URLTextSearcher: Found matching text (match): /download/DragonframeLicenseManager_3.0.0.pkg
{'Output': {'match': '/download/DragonframeLicenseManager_3.0.0.pkg',
            'version': '3.0.0'}}
URLDownloader
{'Input': {'filename': 'DragonframeLicenseServer.pkg',
           'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_15_7) '
                                             'AppleWebKit/537.36 (KHTML, like '
                                             'Gecko) Chrome/131.0.0.0 '
                                             'Safari/537.36'},
           'url': 'https://www.dragonframe.com/download/DragonframeLicenseManager_3.0.0.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 04 Dec 2024 21:06:02 GMT
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.apizz.download.DragonframeLicenseServer/downloads/DragonframeLicenseServer.pkg
{'Output': {'download_changed': True,
            'last_modified': 'Wed, 04 Dec 2024 21:06:02 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.apizz.download.DragonframeLicenseServer/downloads/DragonframeLicenseServer.pkg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.apizz.download.DragonframeLicenseServer/downloads/DragonframeLicenseServer.pkg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: DZED Systems '
                                        'LLC (PG7SM8SD8M)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.apizz.download.DragonframeLicenseServer/downloads/DragonframeLicenseServer.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "DragonframeLicenseServer.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2024-12-04 21:04:33 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: DZED Systems LLC (PG7SM8SD8M)
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            0E 07 04 8A F3 07 53 C8 9D DA 4C 6C 8A A6 E4 20 D6 B6 31 A0 BE 67 
CodeSignatureVerifier:            DB CC FC 53 83 27 E5 36 C3 63
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
FlatPkgUnpacker
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.apizz.download.DragonframeLicenseServer/unpack',
           'flat_pkg_path': '~/Library/AutoPkg/Cache/com.github.apizz.download.DragonframeLicenseServer/downloads/DragonframeLicenseServer.pkg'}}
FlatPkgUnpacker: Unpacked ~/Library/AutoPkg/Cache/com.github.apizz.download.DragonframeLicenseServer/downloads/DragonframeLicenseServer.pkg to ~/Library/AutoPkg/Cache/com.github.apizz.download.DragonframeLicenseServer/unpack
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.apizz.download.DragonframeLicenseServer/DragonframeLicenseServer',
           'pkg_payload_path': '~/Library/AutoPkg/Cache/com.github.apizz.download.DragonframeLicenseServer/unpack/DragonframeLicenseManager.pkg/Payload'}}
PkgPayloadUnpacker: Unpacked ~/Library/AutoPkg/Cache/com.github.apizz.download.DragonframeLicenseServer/unpack/DragonframeLicenseManager.pkg/Payload to ~/Library/AutoPkg/Cache/com.github.apizz.download.DragonframeLicenseServer/DragonframeLicenseServer
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': [],
           'input_path': '~/Library/AutoPkg/Cache/com.github.apizz.download.DragonframeLicenseServer/DragonframeLicenseServer/Library/Dragonframe '
                         'License Manager/DragonframeLicenseManager',
           'requirement': 'identifier DragonframeLicenseManager and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'PG7SM8SD8M'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.apizz.download.DragonframeLicenseServer/DragonframeLicenseServer/Library/Dragonframe License Manager/DragonframeLicenseManager: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.apizz.download.DragonframeLicenseServer/DragonframeLicenseServer/Library/Dragonframe License Manager/DragonframeLicenseManager: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.apizz.download.DragonframeLicenseServer/DragonframeLicenseServer/Library/Dragonframe License Manager/DragonframeLicenseManager: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.apizz.download.DragonframeLicenseServer/receipts/DragonframeLicenseServer.download-receipt-20241224-151933.plist

The following new items were downloaded:
    Download Path                                                                                                                  
    -------------                                                                                                                  
    ~/Library/AutoPkg/Cache/com.github.apizz.download.DragonframeLicenseServer/downloads/DragonframeLicenseServer.pkg
```