### PR TITLE
Use URLTextSearcher for downloading Gapminder Offline

### DIFF
--- a/Gapminder_Offline/GapminderOffline.download.recipe
+++ b/Gapminder_Offline/GapminderOffline.download.recipe
@@ -20,10 +20,21 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>filename</key>
-                <string>%NAME%.dmg</string>
+                <key>re_pattern</key>
+                <string>href="(https://s3-eu-west-1\.amazonaws\.com/gapminder-offline/Gapminder\+Offline-(?P&lt;version&gt;[\d\.]+)-universal\.dmg)"</string>
+                <key>result_output_var_name</key>
+                <string>url</string>
                 <key>url</key>
-                <string>https://s3-eu-west-1.amazonaws.com/gapminder-offline/Gapminder+Offline.dmg</string>
+                <string>https://www.gapminder.org/tools-offline/</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%-%version%.dmg</string>
             </dict>
             <key>Processor</key>
             <string>URLDownloader</string>


### PR DESCRIPTION
This PR fixes the Gapminder Offline download recipe using URLTextSearcher to grab the version and latest URL.

Although there are Intel and Apple Silicon versions available, this recipe grabs the Universal version suitable for either.

Verbose run output:

```
% autopkg run -vvq 'Gapminder_Offline/GapminderOffline.download.recipe'
Processing Gapminder_Offline/GapminderOffline.download.recipe...
WARNING: Gapminder_Offline/GapminderOffline.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="(https://s3-eu-west-1\\.amazonaws\\.com/gapminder-offline/Gapminder\\+Offline-(?P<version>[\\d\\.]+)-universal\\.dmg)"',
           'result_output_var_name': 'url',
           'url': 'https://www.gapminder.org/tools-offline/'}}
URLTextSearcher: Found matching text (version): 6.1.1
URLTextSearcher: Found matching text (url): https://s3-eu-west-1.amazonaws.com/gapminder-offline/Gapminder+Offline-6.1.1-universal.dmg
{'Output': {'url': 'https://s3-eu-west-1.amazonaws.com/gapminder-offline/Gapminder+Offline-6.1.1-universal.dmg',
            'version': '6.1.1'}}
URLDownloader
{'Input': {'filename': 'GapminderOffline-6.1.1.dmg',
           'url': 'https://s3-eu-west-1.amazonaws.com/gapminder-offline/Gapminder+Offline-6.1.1-universal.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 24 Mar 2023 16:28:02 GMT
URLDownloader: Storing new ETag header: "241010df346f2efb82e5fe4bc7630f23-19"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.apizz.download.gapminderoffline/downloads/GapminderOffline-6.1.1.dmg
{'Output': {'download_changed': True,
            'etag': '"241010df346f2efb82e5fe4bc7630f23-19"',
            'last_modified': 'Fri, 24 Mar 2023 16:28:02 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.apizz.download.gapminderoffline/downloads/GapminderOffline-6.1.1.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.apizz.download.gapminderoffline/downloads/GapminderOffline-6.1.1.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.apizz.download.gapminderoffline/downloads/GapminderOffline-6.1.1.dmg/Gapminder '
                         'Offline.app',
           'requirement': 'identifier "com.electron.gapminder-offline" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'J7SD4Z498H',
           'strict_verification': True}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.apizz.download.gapminderoffline/downloads/GapminderOffline-6.1.1.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /private/tmp/dmg.KFthzS/Gapminder Offline.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.KFthzS/Gapminder Offline.app: satisfies its Designated Requirement
CodeSignatureVerifier: test-requirement: code failed to satisfy specified code requirement(s)
Code signature verification failed. Note that all verifications can be disabled by setting the variable DISABLE_CODE_SIGNATURE_VERIFICATION to a non-empty value.
Failed.
Receipt written to ~/Library/AutoPkg/Cache/com.github.apizz.download.gapminderoffline/receipts/GapminderOffline.download-receipt-20241224-185445.plist

The following recipes failed:
    Gapminder_Offline/GapminderOffline.download.recipe
        Error in com.github.apizz.download.gapminderoffline: Processor: CodeSignatureVerifier: Error: Code signature verification failed. Note that all verifications can be disabled by setting the variable DISABLE_CODE_SIGNATURE_VERIFICATION to a non-empty value.

The following new items were downloaded:
    Download Path                                                                                                        
    -------------                                                                                                        
    ~/Library/AutoPkg/Cache/com.github.apizz.download.gapminderoffline/downloads/GapminderOffline-6.1.1.dmg
```