### PR TITLE
Use download rest API for retrieving latest M32Edit

### DIFF
--- a/Midas_M32/MidasM32Edit.download.recipe
+++ b/Midas_M32/MidasM32Edit.download.recipe
@@ -17,9 +17,11 @@
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
-                <string>(downloads\.musictribe\.com/.*/M32-Edit_MAC_[\d.]+\.zip)</string>
+                <string>"(https://mediadl\.musictribe\.com/[\S/]+/M32-Edit_MAC_[\d\.]+\.zip)"</string>
                 <key>url</key>
-                <string>https://www.midasconsoles.com/Categories/Midas/Mixers/Digital/M32/p/P0B3I/Downloads</string>
+                <string>https://www.midasconsoles.com/.rest/musictribe/v1/downloadcenter/solr-dldatatable?brandName=midas&amp;showLegacy=true&amp;modelCode=0603-AEP&amp;type=Software&amp;subtype=Mac&amp;sEcho=60&amp;iColumns=6&amp;iDisplayStart=0&amp;iDisplayLength=60&amp;mDataProp_0=modelName&amp;sSearch_0=&amp;bRegex_0=false&amp;bSearchable_0=true&amp;bSortable_0=true&amp;mDataProp_1=groupName&amp;sSearch_1=&amp;bRegex_1=false&amp;bSearchable_1=true&amp;bSortable_1=true&amp;mDataProp_2=title&amp;sSearch_2=&amp;bRegex_2=false&amp;bSearchable_2=true&amp;bSortable_2=true&amp;mDataProp_3=releaseNotes&amp;sSearch_3=&amp;bRegex_3=false&amp;bSearchable_3=true&amp;bSortable_3=true&amp;mDataProp_4=date&amp;sSearch_4=&amp;bRegex_4=false&amp;bSearchable_4=true&amp;bSortable_4=true&amp;mDataProp_5=url&amp;sSearch_5=&amp;bRegex_5=false&amp;bSearchable_5=true&amp;bSortable_5=true&amp;sSearch=&amp;bRegex=false&amp;iSortCol_0=4&amp;sSortDir_0=desc&amp;iSortingCols=1</string>
+                <key>result_output_var_name</key>
+                <string>url</string>
             </dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>
@@ -29,8 +31,6 @@
             <dict>
                 <key>filename</key>
                 <string>%NAME%.zip</string>
-                <key>url</key>
-                <string>https://%match%</string>
             </dict>
             <key>Processor</key>
             <string>URLDownloader</string>
@@ -54,7 +54,7 @@
             <key>Arguments</key>
             <dict>
                 <key>pattern</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/M32*.app</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/M32-Edit*/M32-Edit.app</string>
             </dict>
             <key>Processor</key>
             <string>FileFinder</string>


### PR DESCRIPTION
This PR fixes the M32Edit download, using the same rest API as the downloads page.

Verbose recipe run output:

```
% autopkg run -vvq 'Midas_M32/MidasM32Edit.download.recipe'
Processing Midas_M32/MidasM32Edit.download.recipe...
WARNING: Midas_M32/MidasM32Edit.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '"(https://mediadl\\.musictribe\\.com/[\\S/]+/M32-Edit_MAC_[\\d\\.]+\\.zip)"',
           'result_output_var_name': 'url',
           'url': 'https://www.midasconsoles.com/.rest/musictribe/v1/downloadcenter/solr-dldatatable?brandName=midas&showLegacy=true&modelCode=0603-AEP&type=Software&subtype=Mac&sEcho=60&iColumns=6&iDisplayStart=0&iDisplayLength=60&mDataProp_0=modelName&sSearch_0=&bRegex_0=false&bSearchable_0=true&bSortable_0=true&mDataProp_1=groupName&sSearch_1=&bRegex_1=false&bSearchable_1=true&bSortable_1=true&mDataProp_2=title&sSearch_2=&bRegex_2=false&bSearchable_2=true&bSortable_2=true&mDataProp_3=releaseNotes&sSearch_3=&bRegex_3=false&bSearchable_3=true&bSortable_3=true&mDataProp_4=date&sSearch_4=&bRegex_4=false&bSearchable_4=true&bSortable_4=true&mDataProp_5=url&sSearch_5=&bRegex_5=false&bSearchable_5=true&bSortable_5=true&sSearch=&bRegex=false&iSortCol_0=4&sSortDir_0=desc&iSortingCols=1'}}
URLTextSearcher: Found matching text (url): https://mediadl.musictribe.com/download/software/midas_M32/M32-Edit_MAC_4.3.zip
{'Output': {'url': 'https://mediadl.musictribe.com/download/software/midas_M32/M32-Edit_MAC_4.3.zip'}}
URLDownloader
{'Input': {'filename': 'M32Edit.zip',
           'url': 'https://mediadl.musictribe.com/download/software/midas_M32/M32-Edit_MAC_4.3.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 29 Apr 2021 13:37:35 GMT
URLDownloader: Storing new ETag header: "98d243d0fc3cd71:0"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.apizz.download.M32Edit/downloads/M32Edit.zip
{'Output': {'download_changed': True,
            'etag': '"98d243d0fc3cd71:0"',
            'last_modified': 'Thu, 29 Apr 2021 13:37:35 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.apizz.download.M32Edit/downloads/M32Edit.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.apizz.download.M32Edit/downloads/M32Edit.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.apizz.download.M32Edit/M32Edit',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename M32Edit.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.apizz.download.M32Edit/downloads/M32Edit.zip to ~/Library/AutoPkg/Cache/com.github.apizz.download.M32Edit/M32Edit
{'Output': {}}
FileFinder
{'Input': {'pattern': '~/Library/AutoPkg/Cache/com.github.apizz.download.M32Edit/M32Edit/M32-Edit*/M32-Edit.app'}}
FileFinder: No value supplied for find_method, setting default value of: glob
FileFinder: Found file match: '~/Library/AutoPkg/Cache/com.github.apizz.download.M32Edit/M32Edit/M32-Edit_4.3/M32-Edit.app' from globbed '~/Library/AutoPkg/Cache/com.github.apizz.download.M32Edit/M32Edit/M32-Edit*/M32-Edit.app'
FileFinder: Basename match: 'M32-Edit.app'
{'Output': {'found_basename': 'M32-Edit.app',
            'found_filename': '~/Library/AutoPkg/Cache/com.github.apizz.download.M32Edit/M32Edit/M32-Edit_4.3/M32-Edit.app'}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.apizz.download.M32Edit/M32Edit/M32-Edit_4.3/M32-Edit.app',
           'requirement': 'identifier "com.musictribe.M32-Edit" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'KZ84TRLT54',
           'strict_verification': True}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.apizz.download.M32Edit/M32Edit/M32-Edit_4.3/M32-Edit.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.apizz.download.M32Edit/M32Edit/M32-Edit_4.3/M32-Edit.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.apizz.download.M32Edit/M32Edit/M32-Edit_4.3/M32-Edit.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.apizz.download.M32Edit/receipts/MidasM32Edit.download-receipt-20241224-191703.plist

The following new items were downloaded:
    Download Path                                                                                
    -------------                                                                                
    ~/Library/AutoPkg/Cache/com.github.apizz.download.M32Edit/downloads/M32Edit.zip
```
