### PR TITLE
Clean up and fix SMART Utility recipes

### DIFF
--- a/SMART_Utility/SMARTUtility.download.recipe
+++ b/SMART_Utility/SMARTUtility.download.recipe
@@ -18,6 +18,15 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the SMART Utility recipes in the flammable-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>

--- a/SMART_Utility/SMARTUtility.pkg.recipe
+++ b/SMART_Utility/SMARTUtility.pkg.recipe
@@ -14,64 +14,17 @@
     <key>MinimumVersion</key>
     <string>1.0.0</string>
     <key>ParentRecipe</key>
-    <string>com.github.apizz.download.smartutility</string>
+    <string>com.github.flammable.download.SMARTUtility</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>pkgdirs</key>
-                <dict>
-                    <key>Applications</key>
-                    <string>0775</string>
-                </dict>
-                <key>pkgroot</key>
-                <string>%RECIPE_CACHE_DIR%/pkgroot</string>
+                <key>app_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Applications/SMART Utility/SMART Utility.app</string>
             </dict>
             <key>Processor</key>
-            <string>PkgRootCreator</string>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>archive_path</key>
-                <string>%pathname%</string>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/pkgroot/Applications</string>
-                <key>purge_destination</key>
-                <true/>
-            </dict>
-            <key>Processor</key>
-            <string>Unarchiver</string>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>pkg_request</key>
-                <dict>
-                    <key>chown</key>
-                    <array>
-                        <dict>
-                            <key>group</key>
-                            <string>admin</string>
-                            <key>path</key>
-                            <string>Applications</string>
-                            <key>user</key>
-                            <string>root</string>
-                        </dict>
-                    </array>
-                    <key>id</key>
-                    <string>com.volitans-software.SMARTUtility</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
-                    <key>pkgname</key>
-                    <string>%NAME%</string>
-                    <key>version</key>
-                    <string>%version%</string>
-                </dict>
-            </dict>
-            <key>Processor</key>
-            <string>PkgCreator</string>
+            <string>AppPkgCreator</string>
         </dict>
     </array>
 </dict>


### PR DESCRIPTION
This PR simplifies the SMARTUtility pkg recipe by switching to an existing download recipe in flammable-recipes as a parent, and deprecates the non-functional SMARTUtility download recipe in this repo.

Verbose recipe run output:

```
% autopkg run -vvq 'SMART_Utility/SMARTUtility.pkg.recipe'
Processing SMART_Utility/SMARTUtility.pkg.recipe...
WARNING: SMART_Utility/SMARTUtility.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'alternate_xmlns_url': 'https://www.andymatuschak.org/xml-namespaces/sparkle',
           'appcast_url': 'https://www.volitans-software.com/stats/smart-utility/profileInfo.php'}}
SparkleUpdateInfoProvider: Items in feed: 1
SparkleUpdateInfoProvider: Items in default channel: 1
SparkleUpdateInfoProvider: Version retrieved from appcast: 3C142
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 3.2.7
SparkleUpdateInfoProvider: Found URL https://cloudfront.volitans-software.com/smartutility327.zip
{'Output': {'url': 'https://cloudfront.volitans-software.com/smartutility327.zip',
            'version': '3.2.7'}}
URLDownloader
{'Input': {'filename': 'SMARTUtility-3.2.7.zip',
           'url': 'https://cloudfront.volitans-software.com/smartutility327.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 29 Apr 2022 15:30:16 GMT
URLDownloader: Storing new ETag header: "83e667cc296e5c0a7866b51b1f9ab1c0"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.apizz.pkg.smartutility/downloads/SMARTUtility-3.2.7.zip
{'Output': {'download_changed': True,
            'etag': '"83e667cc296e5c0a7866b51b1f9ab1c0"',
            'last_modified': 'Fri, 29 Apr 2022 15:30:16 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.apizz.pkg.smartutility/downloads/SMARTUtility-3.2.7.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.apizz.pkg.smartutility/downloads/SMARTUtility-3.2.7.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.apizz.pkg.smartutility/downloads/SMARTUtility-3.2.7.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.apizz.pkg.smartutility/SMARTUtility/Applications',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename SMARTUtility-3.2.7.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.apizz.pkg.smartutility/downloads/SMARTUtility-3.2.7.zip to ~/Library/AutoPkg/Cache/com.github.apizz.pkg.smartutility/SMARTUtility/Applications
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.apizz.pkg.smartutility/SMARTUtility/Applications/SMART '
                         'Utility/SMART Utility.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.volitans-software.smartutility" and '
                          '(certificate leaf[field.1.2.840.113635.100.6.1.9] '
                          '/* exists */ or certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'YJ65CCRY6B)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.apizz.pkg.smartutility/SMARTUtility/Applications/SMART Utility/SMART Utility.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.apizz.pkg.smartutility/SMARTUtility/Applications/SMART Utility/SMART Utility.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.apizz.pkg.smartutility/SMARTUtility/Applications/SMART Utility/SMART Utility.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.apizz.pkg.smartutility/SMARTUtility/Applications/SMART '
                       'Utility/SMART Utility.app',
           'version': '3.2.7'}}
AppPkgCreator: BundleID: com.volitans-software.smartutility
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.apizz.pkg.smartutility/SMARTUtility/Applications/SMART Utility/SMART Utility.app to ~/Library/AutoPkg/Cache/com.github.apizz.pkg.smartutility/payload/Applications/SMART Utility.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.volitans-software.smartutility',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.apizz.pkg.smartutility/SMART '
                                                                    'Utility-3.2.7.pkg',
                                                        'version': '3.2.7'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '3.2.7'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.apizz.pkg.smartutility/receipts/SMARTUtility.pkg-receipt-20241227-183519.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.apizz.pkg.smartutility/downloads/SMARTUtility-3.2.7.zip

The following packages were built:
    Identifier                          Version  Pkg Path
    ----------                          -------  --------
    com.volitans-software.smartutility  3.2.7    ~/Library/AutoPkg/Cache/com.github.apizz.pkg.smartutility/SMART Utility-3.2.7.pkg
```
