### PR TITLE
Deprecate TeacherGaming recipes

### DIFF
--- a/TeacherGaming/TeacherGaming.download.recipe
+++ b/TeacherGaming/TeacherGaming.download.recipe
@@ -14,9 +14,18 @@
         <string>TeacherGaming</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>The TeacherGaming app is no longer available for download (details: https://teachergaming.com/). This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
This PR deprecates the TeacherGaming recipes, because the software is no longer available for download ([details](https://teachergaming.com/)).