### PR TITLE
Deprecate StagePlotPro recipes

### DIFF
--- a/Stage_Plot_Pro/StagePlotPro-XPlace.download.recipe
+++ b/Stage_Plot_Pro/StagePlotPro-XPlace.download.recipe
@@ -16,9 +16,18 @@
         <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>StagePlotPro is no longer available for download. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Arguments</key>
             <dict>

--- a/Stage_Plot_Pro/StagePlotPro.download.recipe
+++ b/Stage_Plot_Pro/StagePlotPro.download.recipe
@@ -14,9 +14,18 @@
         <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>StagePlotPro is no longer available for download. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
Searching around the net reveals that many people are having issues downloading StagePlotPro or getting in touch with the developer. The app is likely no longer being developed.

This PR deprecates the StagePlotPro recipes.