### PR TITLE
Adjust download URL and app name for Redis Insight recipes

### DIFF
--- a/RedisInsight/RedisInsight.download.recipe
+++ b/RedisInsight/RedisInsight.download.recipe
@@ -21,7 +21,7 @@
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
                 <key>url</key>
-                <string>https://download.redisinsight.redis.com/latest/RedisInsight-v2-mac-%ARCH%.dmg</string>
+                <string>https://s3.amazonaws.com/redisinsight.download/public/latest/Redis-Insight-mac-%ARCH%.dmg</string>
             </dict>
             <key>Processor</key>
             <string>URLDownloader</string>
@@ -34,7 +34,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%pathname%/RedisInsight*.app</string>
+                <string>%pathname%/Redis Insight.app</string>
                 <key>requirement</key>
                 <string>identifier "org.RedisLabs.RedisInsight-V2" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = UUK47G4BAZ</string>
                 <key>strict_verification</key>

--- a/RedisInsight/RedisInsight.pkg.recipe
+++ b/RedisInsight/RedisInsight.pkg.recipe
@@ -25,7 +25,7 @@
             <key>Arguments</key>
             <dict>
                 <key>info_path</key>
-                <string>%pathname%/RedisInsight*.app/Contents/Info.plist</string>
+                <string>%pathname%/Redis Insight.app/Contents/Info.plist</string>
                 <key>plist_keys</key>
                 <dict>
                     <key>CFBundleShortVersionString</key>


### PR DESCRIPTION
This PR adjusts the download URL and app name for Redis Insight.

Verbose recipe run output with default (Intel) architecture:

```
% autopkg run -vvq 'RedisInsight/RedisInsight.download.recipe'
Processing RedisInsight/RedisInsight.download.recipe...
WARNING: RedisInsight/RedisInsight.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'RedisInsight.dmg',
           'url': 'https://s3.amazonaws.com/redisinsight.download/public/latest/Redis-Insight-mac-x64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 27 Dec 2024 14:10:12 GMT
URLDownloader: Storing new ETag header: "a659f511d4cda628f6fd84ce6a523b5e-16"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.apizz.download.RedisInsight/downloads/RedisInsight.dmg
{'Output': {'download_changed': True,
            'etag': '"a659f511d4cda628f6fd84ce6a523b5e-16"',
            'last_modified': 'Fri, 27 Dec 2024 14:10:12 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.apizz.download.RedisInsight/downloads/RedisInsight.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.apizz.download.RedisInsight/downloads/RedisInsight.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.apizz.download.RedisInsight/downloads/RedisInsight.dmg/Redis '
                         'Insight.app',
           'requirement': 'identifier "org.RedisLabs.RedisInsight-V2" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'UUK47G4BAZ',
           'strict_verification': True}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.apizz.download.RedisInsight/downloads/RedisInsight.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /private/tmp/dmg.l2SvKd/Redis Insight.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.l2SvKd/Redis Insight.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.l2SvKd/Redis Insight.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.apizz.download.RedisInsight/receipts/RedisInsight.download-receipt-20241228-230708.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.apizz.download.RedisInsight/downloads/RedisInsight.dmg
```

Verbose recipe run output with Apple Silicon architecture:

```
% autopkg run -vvq 'RedisInsight/RedisInsight.download.recipe' -k ARCH=arm64
Processing RedisInsight/RedisInsight.download.recipe...
WARNING: RedisInsight/RedisInsight.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'RedisInsight.dmg',
           'url': 'https://s3.amazonaws.com/redisinsight.download/public/latest/Redis-Insight-mac-arm64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 27 Dec 2024 14:10:12 GMT
URLDownloader: Storing new ETag header: "6015ff3c2384584911c9abb8c2bf4e3d-15"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.apizz.download.RedisInsight/downloads/RedisInsight.dmg
{'Output': {'download_changed': True,
            'etag': '"6015ff3c2384584911c9abb8c2bf4e3d-15"',
            'last_modified': 'Fri, 27 Dec 2024 14:10:12 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.apizz.download.RedisInsight/downloads/RedisInsight.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.apizz.download.RedisInsight/downloads/RedisInsight.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.apizz.download.RedisInsight/downloads/RedisInsight.dmg/Redis '
                         'Insight.app',
           'requirement': 'identifier "org.RedisLabs.RedisInsight-V2" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'UUK47G4BAZ',
           'strict_verification': True}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.apizz.download.RedisInsight/downloads/RedisInsight.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /private/tmp/dmg.m2eDfS/Redis Insight.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.m2eDfS/Redis Insight.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.m2eDfS/Redis Insight.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.apizz.download.RedisInsight/receipts/RedisInsight.download-receipt-20241228-230819.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.apizz.download.RedisInsight/downloads/RedisInsight.dmg
```
