### PR TITLE
Update file pattern for OpenKiosk download

### DIFF
--- a/OpenKiosk/OpenKiosk.download.recipe
+++ b/OpenKiosk/OpenKiosk.download.recipe
@@ -19,9 +19,11 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>(?P&lt;url&gt;https\:\/\/www\.mozdevgroup.com\/.*\/openkiosk-(?P&lt;version&gt;[\d.]+)-(?P&lt;date&gt;[\d-]+)\.dmg)</string>
+				<string>https://www\.mozdevgroup\.com/dropbox/okcd/\d+/release/OpenKiosk[\d\.-]+-universal\.dmg</string>
 				<key>url</key>
 				<string>https://openkiosk.mozdevgroup.com/</string>
+				<key>result_output_var_name</key>
+				<string>url</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>
@@ -31,8 +33,6 @@
 			<dict>
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
-				<key>url</key>
-				<string>%url%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
This PR updates the file pattern used to download OpenKiosk.

I notice the old pattern captured `version` and `date` variables but didn't do anything with them, so I left them out for simplicity.

Verbose recipe run output:

```
% autopkg run -vvq 'OpenKiosk/OpenKiosk.download.recipe'
Processing OpenKiosk/OpenKiosk.download.recipe...
WARNING: OpenKiosk/OpenKiosk.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'https://www\\.mozdevgroup\\.com/dropbox/okcd/\\d+/release/OpenKiosk[\\d\\.-]+-universal\\.dmg',
           'result_output_var_name': 'url',
           'url': 'https://openkiosk.mozdevgroup.com/'}}
URLTextSearcher: Found matching text (url): https://www.mozdevgroup.com/dropbox/okcd/115/release/OpenKiosk115.18.0-2024-12-02-universal.dmg
{'Output': {'url': 'https://www.mozdevgroup.com/dropbox/okcd/115/release/OpenKiosk115.18.0-2024-12-02-universal.dmg'}}
URLDownloader
{'Input': {'filename': 'OpenKiosk.dmg',
           'url': 'https://www.mozdevgroup.com/dropbox/okcd/115/release/OpenKiosk115.18.0-2024-12-02-universal.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 02 Dec 2024 21:26:23 GMT
URLDownloader: Storing new ETag header: "71cb5e0-628503350be3b"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.apizz.download.OpenKiosk/downloads/OpenKiosk.dmg
{'Output': {'download_changed': True,
            'etag': '"71cb5e0-628503350be3b"',
            'last_modified': 'Mon, 02 Dec 2024 21:26:23 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.apizz.download.OpenKiosk/downloads/OpenKiosk.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.apizz.download.OpenKiosk/downloads/OpenKiosk.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.apizz.download.OpenKiosk/receipts/OpenKiosk.download-receipt-20241228-230116.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.apizz.download.OpenKiosk/downloads/OpenKiosk.dmg
```
