### PR TITLE
Remove empty `expected_authority_names` array in CodeSignatureVerifier arguments

### DIFF
--- a/Adobe_Acrobat/AdobeAcrobat2020.pkg.recipe
+++ b/Adobe_Acrobat/AdobeAcrobat2020.pkg.recipe
@@ -53,8 +53,6 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>expected_authority_names</key>
-                <array/>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Adobe Acrobat.app</string>
                 <key>requirement</key>

--- a/Autodesk/AutodeskMaya2020Import.munki.recipe
+++ b/Autodesk/AutodeskMaya2020Import.munki.recipe
@@ -231,8 +231,6 @@ done</string>
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>expected_authority_names</key>
-                <array/>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Autodesk/maya2020/Maya.app</string>
                 <key>requirement</key>

--- a/BlackHole/BlackHoleDriver.download.recipe
+++ b/BlackHole/BlackHoleDriver.download.recipe
@@ -88,8 +88,6 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>expected_authority_names</key>
-                <array/>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Library/Audio/Plug-Ins/HAL/BlackHole.driver</string>
                 <key>requirement</key>

--- a/CLEditor/YamahaCLEditor.download.recipe
+++ b/CLEditor/YamahaCLEditor.download.recipe
@@ -117,8 +117,6 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>expected_authority_names</key>
-                <array/>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Applications/CL Editor.app</string>
                 <key>requirement</key>

--- a/Code42/Code42-arm64.download.recipe
+++ b/Code42/Code42-arm64.download.recipe
@@ -70,8 +70,6 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>expected_authority_names</key>
-                <array/>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Code42.app</string>
                 <key>requirement</key>

--- a/Code42/Code42.download.recipe
+++ b/Code42/Code42.download.recipe
@@ -70,8 +70,6 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>expected_authority_names</key>
-                <array/>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Code42.app</string>
                 <key>requirement</key>

--- a/CrowdStrike/CrowdStrikeFalcon.munki.recipe
+++ b/CrowdStrike/CrowdStrikeFalcon.munki.recipe
@@ -154,8 +154,6 @@ writelog "*****  Install CrowdStrike Process:  COMPLETE  *****"</string>
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>expected_authority_names</key>
-                <array/>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Falcon.app</string>
                 <key>requirement</key>

--- a/Dragonframe/Dragonframe4.munki.recipe
+++ b/Dragonframe/Dragonframe4.munki.recipe
@@ -43,8 +43,6 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>expected_authority_names</key>
-                <array/>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/unpack/Applications/Dragonframe 4/Dragonframe 4.app</string>
                 <key>requirement</key>

--- a/Dragonframe/DragonframeLicenseServer.download.recipe
+++ b/Dragonframe/DragonframeLicenseServer.download.recipe
@@ -84,8 +84,6 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>expected_authority_names</key>
-                <array/>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Library/Dragonframe License Manager/DragonframeLicenseManager</string>
                 <key>requirement</key>

--- a/Eu_Control/EuControlImport.pkg.recipe
+++ b/Eu_Control/EuControlImport.pkg.recipe
@@ -90,8 +90,6 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>expected_authority_names</key>
-                <array/>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Applications/EuControl.app</string>
                 <key>requirement</key>

--- a/FileMaker/FileMakerAdvanced.munki.recipe
+++ b/FileMaker/FileMakerAdvanced.munki.recipe
@@ -71,8 +71,6 @@ When purchasing FileMaker, the order confirmation email includes a URL which tak
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>expected_authority_names</key>
-                <array/>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Applications/FileMaker Pro %MAJOR_VERSION% Advanced/FileMaker Pro Advanced.app</string>
                 <key>requirement</key>

--- a/FortiClient/FortiClientImport.pkg.recipe
+++ b/FortiClient/FortiClientImport.pkg.recipe
@@ -111,8 +111,6 @@ More valuable when used as a parent recipe to bring FortiClient into munki, Jamf
             <string>Check the app code signature.</string>
             <key>Arguments</key>
             <dict>
-                <key>expected_authority_names</key>
-                <array/>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/FortiClient.app</string>
                 <key>requirement</key>

--- a/Karabiner-Elements/Karabiner-Elements.download.recipe
+++ b/Karabiner-Elements/Karabiner-Elements.download.recipe
@@ -94,8 +94,6 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>expected_authority_names</key>
-                <array/>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Karabiner-Elements.app</string>
                 <key>requirement</key>
@@ -122,8 +120,6 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>expected_authority_names</key>
-                <array/>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Library/Application Support/org.pqrs/Karabiner-DriverKit-VirtualHIDDevice/Applications/Karabiner-VirtualHIDDevice-Daemon.app</string>
                 <key>requirement</key>

--- a/Kensington_TrackballWorks/KensingtonWorks.download.recipe
+++ b/Kensington_TrackballWorks/KensingtonWorks.download.recipe
@@ -93,8 +93,6 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>expected_authority_names</key>
-                <array/>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Applications/KensingtonWorks .app</string>
                 <key>requirement</key>
@@ -108,8 +106,6 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>expected_authority_names</key>
-                <array/>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Library/Application Support/Kensington/KensingtonWorks2/KensingtonWorksHelper.app</string>
                 <key>requirement</key>

--- a/Livestream/LivestreamStudio.download.recipe
+++ b/Livestream/LivestreamStudio.download.recipe
@@ -68,8 +68,6 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>expected_authority_names</key>
-                <array/>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/LiveStream Studio.app</string>
                 <key>requirement</key>

--- a/LoggerPro_License/LoggerPro_License.pkg.recipe
+++ b/LoggerPro_License/LoggerPro_License.pkg.recipe
@@ -42,8 +42,6 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>expected_authority_names</key>
-				<array/>
 				<key>input_path</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/Logger Pro.app</string>
 				<key>requirement</key>

--- a/MathType/MathType.munki.recipe
+++ b/MathType/MathType.munki.recipe
@@ -69,8 +69,6 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>expected_authority_names</key>
-                <array/>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Applications/MathType/MathType.app</string>
                 <key>requirement</key>

--- a/Microsoft_Teams/MicrosoftTeams.pkg.recipe
+++ b/Microsoft_Teams/MicrosoftTeams.pkg.recipe
@@ -51,8 +51,6 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>expected_authority_names</key>
-                <array/>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Microsoft Teams.app</string>
                 <key>requirement</key>
@@ -102,8 +100,6 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>expected_authority_names</key>
-                <array/>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Library/Audio/Plug-Ins/HAL/MSTeamsAudioDevice.driver</string>
                 <key>requirement</key>

--- a/Rising_Software/Auralia.download.recipe
+++ b/Rising_Software/Auralia.download.recipe
@@ -91,8 +91,6 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>expected_authority_names</key>
-                <array/>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Auralia 5.app</string>
                 <key>requirement</key>

--- a/Rising_Software/AuraliaCloud.munki.recipe
+++ b/Rising_Software/AuraliaCloud.munki.recipe
@@ -67,8 +67,6 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>expected_authority_names</key>
-                <array/>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Auralia 5 Cloud.app</string>
                 <key>requirement</key>

--- a/Rising_Software/Musition.download.recipe
+++ b/Rising_Software/Musition.download.recipe
@@ -91,8 +91,6 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>expected_authority_names</key>
-                <array/>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Musition 5.app</string>
                 <key>requirement</key>

--- a/Shure_Wireless_Workbench/ShureWirelessWorkbench6.munki.recipe
+++ b/Shure_Wireless_Workbench/ShureWirelessWorkbench6.munki.recipe
@@ -67,8 +67,6 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>expected_authority_names</key>
-                <array/>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Wireless Workbench 6.app</string>
                 <key>requirement</key>

--- a/TuxeraNTFS/TuxeraNTFS.munki.recipe
+++ b/TuxeraNTFS/TuxeraNTFS.munki.recipe
@@ -81,8 +81,6 @@ rm -f /Library/Preferences/com.tuxera.NTFS.plist</string>
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>expected_authority_names</key>
-                <array/>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Tuxera Disk Manager.app</string>
                 <key>requirement</key>
@@ -126,8 +124,6 @@ rm -f /Library/Preferences/com.tuxera.NTFS.plist</string>
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>expected_authority_names</key>
-                <array/>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Library/PreferencePanes/Tuxera NTFS.prefPane</string>
                 <key>requirement</key>
@@ -186,4 +182,3 @@ rm -f /Library/Preferences/com.tuxera.NTFS.plist</string>
     </array>
 </dict>
 </plist>
-

--- a/Wacom/WacomTablet.munki.recipe
+++ b/Wacom/WacomTablet.munki.recipe
@@ -126,8 +126,6 @@ exit 0</string>
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>expected_authority_names</key>
-                <array/>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Library/PreferencePanes/WacomTablet.prefPane</string>
                 <key>requirement</key>

--- a/macFUSE/macFUSE.download.recipe
+++ b/macFUSE/macFUSE.download.recipe
@@ -89,8 +89,6 @@
             <string>Verify .fs code signature</string>
             <key>Arguments</key>
             <dict>
-                <key>expected_authority_names</key>
-                <array/>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Library/Filesystems/macfuse.fs</string>
                 <key>requirement</key>
@@ -106,8 +104,6 @@
             <string>Verify .framework code signature</string>
             <key>Arguments</key>
             <dict>
-                <key>expected_authority_names</key>
-                <array/>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Library/Frameworks/macFUSE.framework</string>
                 <key>requirement</key>
@@ -136,8 +132,6 @@
             <string>Verify .prefPane code signature</string>
             <key>Arguments</key>
             <dict>
-                <key>expected_authority_names</key>
-                <array/>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Library/PreferencePanes/macFUSE.prefPane</string>
                 <key>requirement</key>


### PR DESCRIPTION
As long as there is a valid `requirements` argument, the `expected_authority_names` argument is not needed for code signature verification. This pull request removes the unnecessary empty `expected_authority_names` array.

Thanks for considering!

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0.