### PR TITLE
Update VSCodium.download.recipe

### DIFF
--- a/VSCodium/VSCodium.download.recipe
+++ b/VSCodium/VSCodium.download.recipe
@@ -51,7 +51,7 @@
                 <key>input_path</key>
                 <string>%pathname%/VSCodium.app</string>
                 <key>requirement</key>
-                <string>identifier "com.vscodium" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = C7S3ZQ2B8V</string>
+                <string>identifier "com.vscodium" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = VC39D2VNQ7</string>
                 <key>strict_verification</key>
                 <true/>
             </dict>


### PR DESCRIPTION
It seems there's been more changes with the vscodium developer cert and the downloads were failing. Checked the signature of the current version:

```
davidfisher ~/src/autopkg-config % codesign --display -r- ~/Downloads/VSCodium.app 
Executable=/Users/davidfisher/Downloads/VSCodium.app/Contents/MacOS/Electron
designated => identifier "com.vscodium" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = VC39D2VNQ7
```  

Updated download recipe accordingly.

