### PR TITLE
Update MidasM32Edit.munki.recipe

### DIFF
--- a/Midas_M32/MidasM32Edit.munki.recipe
+++ b/Midas_M32/MidasM32Edit.munki.recipe
@@ -49,7 +49,7 @@ It provides powerful remote control for all functions, as well as off-line editi
                 <key>dmg_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
                 <key>dmg_root</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                <string>%found_filename%</string>
             </dict>
             <key>Processor</key>
             <string>DmgCreator</string>
@@ -64,6 +64,17 @@ It provides powerful remote control for all functions, as well as off-line editi
             </dict>
             <key>Processor</key>
             <string>MunkiImporter</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
         </dict>
     </array>
 </dict>


### PR DESCRIPTION
Hi, @apizz 

The MidasM32Edit munki recipe is currently failing with 
```
MunkiImporter: Could not find a supported installer item in /Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.M32Edit/M32Edit.dmg!
creating pkginfo for /Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.M32Edit/M32Edit.dmg failed: Could not find a supported installer item in /Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.M32Edit/M32Edit.dmg!

Failed.
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.M32Edit/receipts/MidasM32Edit.munki-receipt-20250226-205615.plist

The following recipes failed:
    MidasM32Edit.munki.recipe
        Error in com.github.apizz.munki.M32Edit: Processor: MunkiImporter: Error: creating pkginfo for /Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.M32Edit/M32Edit.dmg failed: Could not find a supported installer item in /Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.M32Edit/M32Edit.dmg!
```

This PR  changes the dmg_root to be `%found_filename%`  and adds `pathdeleter`

Output from a successful -v run
```
autopkg run -v MidasM32Edit.munki.recipe
Looking for com.github.apizz.download.M32Edit...
Did not find com.github.apizz.download.M32Edit in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.apizz.download.M32Edit...
Found com.github.apizz.download.M32Edit in recipe map
**load_recipe time: 0.014566499998181826
Processing MidasM32Edit.munki.recipe...
WARNING: MidasM32Edit.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (url): https://cdn.mediavalet.com/aunsw/musictribe/p_hc2W7JKUKH_Whh4fUWqQ/kStAIRFJ7UaPpQpnm-ryKg/Original/M32-Edit_MAC_4.3.zip
URLDownloader
URLDownloader: Storing new ETag header: 2/26/2025 8:38:08 PM
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.M32Edit/downloads/M32Edit.zip
EndOfCheckPhase
Unarchiver
Unarchiver: Guessed archive format 'zip' from filename M32Edit.zip
Unarchiver: Unarchived /Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.M32Edit/downloads/M32Edit.zip to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.M32Edit/M32Edit
FileFinder
FileFinder: Found file match: '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.M32Edit/M32Edit/M32-Edit_4.3/M32-Edit.app' from globbed '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.M32Edit/M32Edit/M32-Edit*/M32-Edit.app'
FileFinder: Basename match: 'M32-Edit.app'
CodeSignatureVerifier
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.M32Edit/M32Edit/M32-Edit_4.3/M32-Edit.app: valid on disk
CodeSignatureVerifier: /Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.M32Edit/M32Edit/M32-Edit_4.3/M32-Edit.app: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.M32Edit/M32Edit/M32-Edit_4.3/M32-Edit.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
DmgCreator
DmgCreator: Created dmg from /Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.M32Edit/M32Edit/M32-Edit_4.3/M32-Edit.app at /Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.M32Edit/M32Edit.dmg
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/m32edit/M32Edit-4.3.0__1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/m32edit/M32Edit-4.3.0__1.dmg
PathDeleter
PathDeleter: Deleted /Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.M32Edit/M32Edit
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.M32Edit/receipts/MidasM32Edit.munki-receipt-20250226-210609.plist

The following new items were downloaded:
    Download Path                                                                                  
    -------------                                                                                  
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.M32Edit/downloads/M32Edit.zip  

The following new items were imported into Munki:
    Name     Version  Catalogs  Pkginfo Path                         Pkg Repo Path                      Icon Repo Path  
    ----     -------  --------  ------------                         -------------                      --------------  
    M32Edit  4.3.0    testing   apps/m32edit/M32Edit-4.3.0__1.plist  apps/m32edit/M32Edit-4.3.0__1.dmg
```