### PR TITLE
Update smartmontools.download.recipe

### DIFF
--- a/smartmontools/smartmontools.download.recipe
+++ b/smartmontools/smartmontools.download.recipe
@@ -32,7 +32,7 @@
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
-                <string>(https://sourceforge.net/projects/smartmontools/files/smartmontools/[\d.]+/smartmontools-[\d.]+-1.dmg/download)</string>
+                <string>(https://sourceforge.net/projects/smartmontools/files/smartmontools/[\d.]+/smartmontools-[\d.]+.*.dmg/download)</string>
                 <key>result_output_var_name</key>
                 <string>match</string>
                 <key>url</key>


### PR DESCRIPTION
+.* in the re pattern key is a lest strict interpretation which allows the download recipe to work for the current version: 7.5