### PR TITLE
Update Tart.munki.recipe

### DIFF
--- a/Tart/Tart.munki.recipe
+++ b/Tart/Tart.munki.recipe
@@ -42,6 +42,16 @@
     <string>com.github.kevinmcox.pkg.Tart</string>
     <key>Process</key>
     <array>
+		<dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>message</key>
+                <string>⚠️ The recipe com.github.apizz.munki.Tart is deprecated.
+Please use com.github.kevinmcox.munki.Tart going forward.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
Tart now ships as a Universal application so we can remove the architecture support that was added last year.

Corresponding change in the parent recipes is here: https://github.com/autopkg/wegotoeleven-recipes/pull/5

EDIT: After discussion with @wegotoeleven I am adopting the parent recipes and deprecating his.

I went ahead and created a Munki recipe as well so I'd have them all in one place:
https://github.com/autopkg/kevinmcox-recipes/tree/master/Cirrus%20Labs

We can update this to use my package as a parent or this one could be deprecated as well and folks could just be directed to the new one.

EDIT: I went ahead and added a deprecation warning.