### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/Turbo_Boost_Switcher/TurboBoostSwitcher.download.recipe
+++ b/Turbo_Boost_Switcher/TurboBoostSwitcher.download.recipe
@@ -28,7 +28,7 @@
                     <string>%USER_AGENT%</string>
                 </dict>
                 <key>url</key>
-                <string>http://tbswitcher.rugarciap.com/</string>
+                <string>https://tbswitcher.rugarciap.com/</string>
             </dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [back in 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._