### PR TITLE
Update Unity support recipes for new download URLs

### DIFF
--- a/Unity/Unity3DAndroidSupport.download.recipe
+++ b/Unity/Unity3DAndroidSupport.download.recipe
@@ -19,7 +19,7 @@
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
-                <string>(?P&lt;url&gt;https:\/\/[a-z0-9]+\.unity3d\.com\/.*\/UnitySetup-Android-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
+                <string>(?P&lt;url&gt;https:\/\/download\.unity3d\.com\/download_unity\/[0-9a-f]+\/MacEditorTargetInstaller\/UnitySetup-Android-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
                 <key>url</key>
                 <string>https://unity3d.com/unity-release/latest</string>
             </dict>
@@ -46,7 +46,7 @@
             <dict>
                 <key>expected_authority_names</key>
                 <array>
-                    <string>Developer ID Installer: Unity Technologies ApS (BVPN9UFA9B)</string>
+                    <string>Developer ID Installer: Unity Technologies SF (9QW8UQUTAA)</string>
                     <string>Developer ID Certification Authority</string>
                     <string>Apple Root CA</string>
                 </array>

--- a/Unity/Unity3DAppleTVSupport.download.recipe
+++ b/Unity/Unity3DAppleTVSupport.download.recipe
@@ -19,7 +19,7 @@
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
-                <string>(?P&lt;url&gt;https:\/\/[a-z0-9]+\.unity3d\.com\/.*\/UnitySetup-AppleTV-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
+                <string>(?P&lt;url&gt;https:\/\/download\.unity3d\.com\/download_unity\/[0-9a-f]+\/MacEditorTargetInstaller\/UnitySetup-AppleTV-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
                 <key>url</key>
                 <string>https://unity3d.com/unity-release/latest</string>
             </dict>
@@ -46,7 +46,7 @@
             <dict>
                 <key>expected_authority_names</key>
                 <array>
-                    <string>Developer ID Installer: Unity Technologies ApS (BVPN9UFA9B)</string>
+                    <string>Developer ID Installer: Unity Technologies SF (9QW8UQUTAA)</string>
                     <string>Developer ID Certification Authority</string>
                     <string>Apple Root CA</string>
                 </array>

--- a/Unity/Unity3DLinuxSupport.download.recipe
+++ b/Unity/Unity3DLinuxSupport.download.recipe
@@ -3,13 +3,17 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest version of the Unity Linux Target Support installer.</string>
+    <string>Downloads the latest version of the Unity Linux Target Support installer.
+BACKEND is either IP2CPP or Mono.
+    </string>
     <key>Identifier</key>
     <string>com.github.apizz.autopkg.download.Unity3DLinux</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
-        <string>Unity3D_LinuxSupport</string>
+        <string>Unity3D_LinuxSupport_%BACKEND%</string>
+        <key>BACKEND</key>
+        <string>IL2CPP</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.5.0</string>
@@ -19,7 +23,7 @@
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
-                <string>(?P&lt;url&gt;https:\/\/[a-z0-9]+\.unity3d\.com\/.*\/UnitySetup-Linux-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
+                <string>(?P&lt;url&gt;https:\/\/download\.unity3d\.com\/download_unity\/[0-9a-f]+\/MacEditorTargetInstaller\/UnitySetup-Linux-%BACKEND%-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
                 <key>url</key>
                 <string>https://unity3d.com/unity-release/latest</string>
             </dict>
@@ -46,7 +50,7 @@
             <dict>
                 <key>expected_authority_names</key>
                 <array>
-                    <string>Developer ID Installer: Unity Technologies ApS (BVPN9UFA9B)</string>
+                    <string>Developer ID Installer: Unity Technologies SF (9QW8UQUTAA)</string>
                     <string>Developer ID Certification Authority</string>
                     <string>Apple Root CA</string>
                 </array>

--- a/Unity/Unity3DLinuxSupport.munki.recipe
+++ b/Unity/Unity3DLinuxSupport.munki.recipe
@@ -7,7 +7,10 @@
 
 Need to supply the munki item name for Unity 3D in UNITY_MUNKI_ITEM_NAME to correctly link this support installer to it along with the correct version.
 
-A preinstall script in this support package checks to make sure the same version of Unity 3D is installed, otherwise it fails.</string>
+A preinstall script in this support package checks to make sure the same version of Unity 3D is installed, otherwise it fails.
+
+BACKEND is either IP2CPP or Mono.
+    </string>
     <key>Identifier</key>
     <string>com.github.apizz.autopkg.munki.Unity3DLinux</string>
     <key>Input</key>

--- a/Unity/Unity3DWebGLSupport.download.recipe
+++ b/Unity/Unity3DWebGLSupport.download.recipe
@@ -19,7 +19,7 @@
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
-                <string>(?P&lt;url&gt;https:\/\/[a-z0-9]+\.unity3d\.com\/.*\/UnitySetup-WebGL-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
+                <string>(?P&lt;url&gt;https:\/\/download\.unity3d\.com\/download_unity\/[0-9a-f]+\/MacEditorTargetInstaller\/UnitySetup-WebGL-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
                 <key>url</key>
                 <string>https://unity3d.com/unity-release/latest</string>
             </dict>
@@ -46,7 +46,7 @@
             <dict>
                 <key>expected_authority_names</key>
                 <array>
-                    <string>Developer ID Installer: Unity Technologies ApS (BVPN9UFA9B)</string>
+                    <string>Developer ID Installer: Unity Technologies SF (9QW8UQUTAA)</string>
                     <string>Developer ID Certification Authority</string>
                     <string>Apple Root CA</string>
                 </array>

--- a/Unity/Unity3DWindowsSupport.download.recipe
+++ b/Unity/Unity3DWindowsSupport.download.recipe
@@ -19,7 +19,7 @@
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
-                <string>(?P&lt;url&gt;https:\/\/[a-z0-9]+\.unity3d\.com\/.*\/UnitySetup-Windows-Mono-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
+                <string>(?P&lt;url&gt;https:\/\/download\.unity3d\.com\/download_unity\/[0-9a-f]+\/MacEditorTargetInstaller\/UnitySetup-Windows-Mono-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
                 <key>url</key>
                 <string>https://unity3d.com/unity-release/latest</string>
             </dict>
@@ -46,7 +46,7 @@
             <dict>
                 <key>expected_authority_names</key>
                 <array>
-                    <string>Developer ID Installer: Unity Technologies ApS (BVPN9UFA9B)</string>
+                    <string>Developer ID Installer: Unity Technologies SF (9QW8UQUTAA)</string>
                     <string>Developer ID Certification Authority</string>
                     <string>Apple Root CA</string>
                 </array>

--- a/Unity/Unity3DiOSSupport.download.recipe
+++ b/Unity/Unity3DiOSSupport.download.recipe
@@ -19,7 +19,7 @@
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
-                <string>(?P&lt;url&gt;https:\/\/[a-z0-9]+\.unity3d\.com\/.*\/UnitySetup-iOS-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
+                <string>(?P&lt;url&gt;https:\/\/download\.unity3d\.com\/download_unity\/[0-9a-f]+\/MacEditorTargetInstaller\/UnitySetup-iOS-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
                 <key>url</key>
                 <string>https://unity3d.com/unity-release/latest</string>
             </dict>
@@ -46,7 +46,7 @@
             <dict>
                 <key>expected_authority_names</key>
                 <array>
-                    <string>Developer ID Installer: Unity Technologies ApS (BVPN9UFA9B)</string>
+                    <string>Developer ID Installer: Unity Technologies SF (9QW8UQUTAA)</string>
                     <string>Developer ID Certification Authority</string>
                     <string>Apple Root CA</string>
                 </array>

--- a/Unity/Unity3DmacOSSupport.download.recipe
+++ b/Unity/Unity3DmacOSSupport.download.recipe
@@ -19,7 +19,7 @@
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
-                <string>(?P&lt;url&gt;https:\/\/[a-z0-9]+\.unity3d\.com\/.*\/UnitySetup-Mac-IL2CPP-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
+                <string>(?P&lt;url&gt;https:\/\/download\.unity3d\.com\/download_unity\/[0-9a-f]+\/MacEditorTargetInstaller\/UnitySetup-Mac-IL2CPP-Support-for-Editor-(?P&lt;version&gt;[\d.f]+)\.pkg)</string>
                 <key>url</key>
                 <string>https://unity3d.com/unity-release/latest</string>
             </dict>
@@ -46,7 +46,7 @@
             <dict>
                 <key>expected_authority_names</key>
                 <array>
-                    <string>Developer ID Installer: Unity Technologies ApS (BVPN9UFA9B)</string>
+                    <string>Developer ID Installer: Unity Technologies SF (9QW8UQUTAA)</string>
                     <string>Developer ID Certification Authority</string>
                     <string>Apple Root CA</string>
                 </array>


### PR DESCRIPTION
Changed regex patterns in Unity support download recipes to be more specific.
Updated expected installer authority names to 'Unity Technologies SF (9QW8UQUTAA)'.
Added support for different scripting backends for Linux recipes.