### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/BlockBlock/BlockBlock.pkg.recipe
+++ b/BlockBlock/BlockBlock.pkg.recipe
@@ -202,8 +202,6 @@ The native BlockBlock Installer.app utilizes a shell script to install / uninsta
                     </array>
                     <key>id</key>
                     <string>%pkg_id%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%-%version%</string>
                     <key>version</key>

--- a/GAM/GAM.pkg.recipe
+++ b/GAM/GAM.pkg.recipe
@@ -85,8 +85,6 @@
                     </array>
                     <key>id</key>
                     <string>com.github.gam</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%</string>
                     <key>version</key>

--- a/HashiCorp/Vault.pkg.recipe
+++ b/HashiCorp/Vault.pkg.recipe
@@ -66,8 +66,6 @@
                     </array>
                     <key>id</key>
                     <string>com.hashicorp.vault</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%-%version%</string>
                     <key>version</key>

--- a/Sqwarq/CriticalUpdates.pkg.recipe
+++ b/Sqwarq/CriticalUpdates.pkg.recipe
@@ -62,8 +62,6 @@
                     </array>
                     <key>id</key>
                     <string>com.sqwarq.Critical-Updates</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%</string>
                     <key>version</key>

--- a/Sqwarq/FastTasks2.pkg.recipe
+++ b/Sqwarq/FastTasks2.pkg.recipe
@@ -62,8 +62,6 @@
                     </array>
                     <key>id</key>
                     <string>com.sqwarq.FastTasks-2</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%</string>
                     <key>version</key>

--- a/SwiftDefaultApps/SwiftDefaultApps.pkg.recipe
+++ b/SwiftDefaultApps/SwiftDefaultApps.pkg.recipe
@@ -126,8 +126,6 @@ To package only the executable, use SwiftDefaultApps_CLI.pkg.recipe instead.</st
                     </array>
                     <key>id</key>
                     <string>com.github.Lord-Kamina.SwiftDefaultApps</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%-%version%</string>
                     <key>version</key>

--- a/SwiftDefaultApps/SwiftDefaultApps_CLI.pkg.recipe
+++ b/SwiftDefaultApps/SwiftDefaultApps_CLI.pkg.recipe
@@ -77,8 +77,6 @@ To package both the executable and preference pane, use SwiftDefaultApps.pkg.rec
                     </array>
                     <key>id</key>
                     <string>com.github.Lord-Kamina.SwiftDefaultAppsCLI</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%-%version%</string>
                     <key>version</key>

--- a/Turbo_Boost_Switcher/TurboBoostSwitcher.pkg.recipe
+++ b/Turbo_Boost_Switcher/TurboBoostSwitcher.pkg.recipe
@@ -89,8 +89,6 @@
                     </array>
                     <key>id</key>
                     <string>rugarciap.com.Turbo-Boost-Switcher</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%-%version%</string>
                     <key>version</key>

--- a/Unity/Unity3DDocumentation.pkg.recipe
+++ b/Unity/Unity3DDocumentation.pkg.recipe
@@ -92,8 +92,6 @@
                     </array>
                     <key>id</key>
                     <string>com.unity3d.Documentation</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%</string>
                     <key>scripts</key>

--- a/defaultbrowser/defaultbrowser.pkg.recipe
+++ b/defaultbrowser/defaultbrowser.pkg.recipe
@@ -66,8 +66,6 @@
                     </array>
                     <key>id</key>
                     <string>com.github.kerma.defaultbrowser</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%-%version%</string>
                     <key>version</key>

--- a/jamJAR/jamJAR.pkg.recipe
+++ b/jamJAR/jamJAR.pkg.recipe
@@ -84,8 +84,6 @@
                     </array>
                     <key>id</key>
                     <string>com.github.dataJAR.jamJAR</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%-%version%</string>
                     <key>version</key>

--- a/unearth/unearth.pkg.recipe
+++ b/unearth/unearth.pkg.recipe
@@ -140,8 +140,6 @@
                     </array>
                     <key>id</key>
                     <string>com.github.unearth</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%</string>
                     <key>version</key>


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and removes the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._