### PR TITLE
Adjust parent recipe for tallfunnyjew-recipes deprecation

### DIFF
--- a/Telegram/Telegram.munki.recipe
+++ b/Telegram/Telegram.munki.recipe
@@ -37,7 +37,7 @@
     <key>MinimumVersion</key>
     <string>1.0.0</string>
     <key>ParentRecipe</key>
-    <string>com.github.tallfunnyjew.download.Telegram</string>
+    <string>com.github.moofit-recipes.download.Telegram</string>
     <key>Process</key>
     <array>
         <dict>


### PR DESCRIPTION
The tallfunnyjew-recipes repository [will be deprecated and archived](https://github.com/autopkg/tallfunnyjew-recipes/issues/37). This PR switches the Telegram.munki recipe parent recipe to a working copy in the moofit-recipes repository.