### PR TITLE
Update smartmontools.download.recipe

### DIFF
--- a/smartmontools/smartmontools.download.recipe
+++ b/smartmontools/smartmontools.download.recipe
@@ -18,43 +18,72 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>re_pattern</key>
-                <string>/projects/smartmontools/files/smartmontools/([\d.]+)</string>
-                <key>result_output_var_name</key>
-                <string>version</string>
-                <key>url</key>
-                <string>https://sourceforge.net/projects/smartmontools/files/smartmontools/</string>
+                <key>asset_regex</key>
+                <string>smartmontools-.*dmg$</string>
+                <key>github_repo</key>
+                <string>smartmontools/smartmontools</string>
+                <key>include_prereleases</key>
+                <string>%PRERELEASE%</string>
             </dict>
             <key>Processor</key>
-            <string>URLTextSearcher</string>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>re_pattern</key>
-                <string>(https://sourceforge.net/projects/smartmontools/files/smartmontools/[\d.]+/smartmontools-[\d.]+-1.dmg/download)</string>
-                <key>result_output_var_name</key>
-                <string>match</string>
-                <key>url</key>
-                <string>https://sourceforge.net/projects/smartmontools/files/smartmontools/%version%</string>
-            </dict>
-            <key>Processor</key>
-            <string>URLTextSearcher</string>
+            <string>GitHubReleasesInfoProvider</string>
         </dict>
         <dict>
             <key>Arguments</key>
             <dict>
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
-                <key>url</key>
-                <string>%match%</string>
-            </dict>
-            <key>Processor</key>
-            <string>URLDownloader</string>
-        </dict>
+           </dict>
+           <key>Processor</key>
+           <string>URLDownloader</string>
+       </dict>
         <dict>
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pattern</key>
+                <string>%pathname%/smartmontools*.pkg</string>
+            </dict>
+            <key>Processor</key>
+            <string>FileFinder</string>
+        </dict>
+        <dict>
+            <key>Comment</key>
+            <string>Because the smartmontools Github doesn't have a clean release version number, we have to get this ourselves from the PKG</string>
+            <key>Arguments</key>
+            <dict>
+                <key>flat_pkg_path</key>
+                <string>%pathname%/%dmg_found_filename%</string>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpack</string>
+            </dict>
+            <key>Processor</key>
+            <string>FlatPkgUnpacker</string>
+        </dict>
+        <dict>
+            <key>Comment</key>
+            <string>Collect the version number from the extracted flat PKG</string>
+            <key>Arguments</key>
+            <dict>
+                <key>package_info_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpack/PackageInfo</string>
+            </dict>
+            <key>Processor</key>
+            <string>com.facebook.autopkg.shared/PackageInfoVersioner</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/unpack</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
         </dict>
     </array>
 </dict>


### PR DESCRIPTION
Use Github version instead of sourceforge

Closes #126 and replaces #127

verbose run:

```
autopkg run -vvv ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.apizz-recipes/smartmontools/smartmontools.download.recipe
Processing /Users/autopkg/Library/AutoPkg/RecipeRepos/com.github.autopkg.apizz-recipes/smartmontools/smartmontools.download.recipe...
WARNING: /Users/autopkg/Library/AutoPkg/RecipeRepos/com.github.autopkg.apizz-recipes/smartmontools/smartmontools.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
{'AUTOPKG_VERSION': '2.7.6',
 'NAME': 'smartmontools',
 'PARENT_RECIPES': [],
 'RECIPE_CACHE_DIR': '/Users/autopkg/Library/AutoPkg/Cache/com.github.apizz.download.smartmontools',
 'RECIPE_DIR': '/Users/autopkg/Library/AutoPkg/RecipeRepos/com.github.autopkg.apizz-recipes/smartmontools',
 'RECIPE_OVERRIDE_DIRS': ['~/Library/AutoPkg/RecipeOverrides'],
 'RECIPE_PATH': '/Users/autopkg/Library/AutoPkg/RecipeRepos/com.github.autopkg.apizz-recipes/smartmontools/smartmontools.download.recipe',
 'RECIPE_REPOS': {'/Users/autopkg/Library/AutoPkg/RecipeRepos/com.github.autopkg.apizz-recipes': {'URL': 'https://github.com/autopkg/apizz-recipes'},
                  '/Users/autopkg/Library/AutoPkg/RecipeRepos/com.github.facebookarchive.Recipes-for-AutoPkg': {'URL': 'https://github.com/facebookarchive/Recipes-for-AutoPkg'}},
 'RECIPE_SEARCH_DIRS': ['.',
                        '~/Library/AutoPkg/Recipes',
                        '/Library/AutoPkg/Recipes',
                        '/Users/autopkg/Library/AutoPkg/RecipeRepos/com.github.autopkg.apizz-recipes',
                        '/Users/autopkg/Library/AutoPkg/RecipeRepos/com.github.facebookarchive.Recipes-for-AutoPkg'],
 'verbose': 3}
GitHubReleasesInfoProvider
Use of undefined key in variable substitution: 'PRERELEASE'
{'Input': {'asset_regex': 'smartmontools-.*dmg$',
           'github_repo': 'smartmontools/smartmontools',
           'include_prereleases': '%PRERELEASE%'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex 'smartmontools-.*dmg$' among asset(s): smartmontools-7.5.dmg, smartmontools-7.5.dmg.asc, smartmontools-7.5.dmg.md5, smartmontools-7.5.tar.gz, smartmontools-7.5.tar.gz.asc, smartmontools-7.5.tar.gz.md5, smartmontools-7.5.win32-setup.exe, smartmontools-7.5.win32-setup.exe.asc, smartmontools-7.5.win32-setup.exe.md5
GitHubReleasesInfoProvider: Selected asset 'smartmontools-7.5.dmg' from release 'Release 7.5'
{'Output': {'asset_created_at': '2025-05-12T07:04:42Z',
            'asset_url': 'https://api.github.com/repos/smartmontools/smartmontools/releases/assets/253859518',
            'release_notes': '- CI and release builds are now reproducible if '
                             'same SOURCE_DATE_EPOCH,\r\n'
                             '  build recipes and toolchains are used.\r\n'
                             '- smartctl `-j -A`: New JSON value '
                             "'endurance_used' (ATA/SCSI/NVMe).\r\n"
                             '- smartctl `-j -A`: New JSON value '
                             "'spare_available' (ATA/NVMe).\r\n"
                             '- smartctl `-j -i`: Re-added the JSON value '
                             "'model_name' also for SCSI\r\n"
                             '  devices (regression).\r\n'
                             '- smartctl `-j -c`: NVMe support.\r\n'
                             '- smartctl `-j -n ...`: New JSON values '
                             "'power_mode.*' (ATA only).\r\n"
                             '- smartctl `-H -A`: Support for NVMe '
                             'SMART/Health Information per\r\n'
                             '  namespace.\r\n'
                             '- smartctl `-i`: ATA ACS-6 updates.\r\n'
                             '- smartctl `-x`: No longer includes `-g '
                             'wcreorder`.\r\n'
                             '- smartctl `-x`, `-l scterc`: No longer returns '
                             'exit status 4 if SCT ERC\r\n'
                             '  is not supported by the device.\r\n'
                             '- smartctl `-l error`: No longer prints bogus '
                             'ATA error log entries if\r\n'
                             '  the error index is nonzero but the error count '
                             'is zero.\r\n'
                             '- smartctl `-l ssd`: Fixed corruption of the '
                             'output of the SCSI Format\r\n'
                             '  Status log page.\r\n'
                             "- smartctl `-l ssd`: Now detects 'no format "
                             "since manufacture' from the\r\n"
                             '  SCSI Format Status log page.\r\n'
                             "- smartctl `-l farm`: Fixed the unit of 'Write "
                             "Power On' time.\r\n"
                             '- smartctl `-l farm`: Fixed the byte order of '
                             "ATA 'Assembly Date'.\r\n"
                             '- smartctl `-l farm`: Fixed a possible '
                             'segfault.\r\n'
                             '- smartctl `-l farm -q noserial`: Suppresses '
                             'serial and WWN also from FARM.\r\n'
                             '- smartctl `-l farm -T permissive`: Overrides '
                             'false negative FARM support\r\n'
                             '  check for rebranded drives.\r\n'
                             '- smartctl `-t TEST`: Fixed self-tests of single '
                             'namespace NVMe devices.\r\n'
                             '- smartd `-A`: NVMe attribute log support.\r\n'
                             '- smartd: Ignores NSID in duplicate check of '
                             'single namespace devices.\r\n'
                             '- smartd: No longer issues LOG_CRIT warnings for '
                             "'Set Feature' related\r\n"
                             '  NVMe error information log entries.\r\n'
                             '- smartd: No longer hangs on systems with large '
                             'file descriptor limits.\r\n'
                             '- smartd: No longer logs invalid "old test ... '
                             'not run" messages if\r\n'
                             '  staggered self-tests are used.\r\n'
                             '- smartd.conf `-l selftest[sts] -s ...`: NVMe '
                             'self-test support.\r\n'
                             '- smartd.conf `-H MASK`: Ability to ignore '
                             'specific bits of NVMe\r\n'
                             "  SMART/Health value 'Critical Warning'.\r\n"
                             '- smartd.conf `-p`: Checks NVMe SMART/Health '
                             "value 'Available Spare'.\r\n"
                             '- smartd.conf `-u [-f]`: Checks NVMe '
                             "SMART/Health values 'Percentage Used'\r\n"
                             "  and 'Media and Data Integrity Errors'.\r\n"
                             '- smartd.conf `-W ...`: No longer includes '
                             'individual sensors in NVMe\r\n'
                             '  temperature check as some devices report other '
                             'values there.\r\n'
                             '- ATA: Device type `-d jmb39x-q2,N` for another '
                             'JMB39x protocol variant\r\n'
                             '  used by QNAP-TR002 NAS devices.\r\n'
                             '- SCSI: Fixed range checks of mode page offset '
                             'and VPD inquiry.\r\n'
                             '- SCSI: Fixed buffer overflow parsing of VPD '
                             'page.\r\n'
                             '- SCSI: Fixed handling of multiple designators '
                             'in VPD page.\r\n'
                             '- USB/NVMe: `-d sntjmicron` no longer triggers '
                             'USB resets on queries of\r\n'
                             '  the self-test log.\r\n'
                             '- USB/NVMe: `-d sntasmedia` now supports log '
                             'pages > 512 bytes.\r\n'
                             '- USB/NVMe/SAT: New experimental NVMe/SAT '
                             'autodetection options\r\n'
                             '  `-d snt*/sat`.\r\n'
                             '- Fixed segfault on missing option argument on '
                             'systems using musl libc.\r\n'
                             '- HDD, SSD and USB additions to drive '
                             'database.\r\n'
                             '- automake < 1.13 are no longer supported.\r\n'
                             '- Custom make rules are now silenced if `make '
                             'V=0` is used.\r\n'
                             '- Enhanced makefile targets `dist-*` to create '
                             'reproducible source\r\n'
                             '  tarballs if SOURCE_DATE_EPOCH is set.\r\n'
                             '- The makefile no longer uses GNU make specific '
                             'syntax elements\r\n'
                             '  (exception: reproducible builds for macOS).\r\n'
                             '- Dropped support for platforms without '
                             '`sigaction()`.\r\n'
                             '- configure: Now also detects MidnightBSD.\r\n'
                             '- configure: Dropped option '
                             '`--with-signal-func`.\r\n'
                             '- configure: Default for '
                             "`--with-nvme-devicescan` is now 'yes' also on\r\n"
                             '  NetBSD.\r\n'
                             '- Version information is now also set if build '
                             'from GH R/O mirror.\r\n'
                             '- Linux: `smartd.service` now avoids a warning '
                             'about an unset environment\r\n'
                             '  variable.\r\n'
                             '- Linux: Dropped autodetection of deprecated '
                             'device type `-d marvell`.\r\n'
                             '- macOS: Support for reproducible builds of the '
                             'DMG image.\r\n'
                             '- OpenBSD: NVMe support.\r\n'
                             '- Windows: Increased WMI timeout.\r\n'
                             '- Windows: Support for reproducible builds of '
                             'the installer.\r\n'
                             '- Windows: Uninstaller is no longer damaged if '
                             'the installer is signed.\r\n'
                             '- Windows `update-smartd-drivedb.ps1`: Fixed '
                             'call of `gpg.exe` if it\r\n'
                             '  appears more than once in the PATH.\r\n'
                             '- Windows `update-smartd-drivedb.ps1 -Verbose`: '
                             'Now also prints the\r\n'
                             '  download command.\r\n',
            'url': 'https://github.com/smartmontools/smartmontools/releases/download/RELEASE_7_5/smartmontools-7.5.dmg',
            'version': 'RELEASE_7_5'}}
URLDownloader
{'Input': {'filename': 'smartmontools.dmg',
           'url': 'https://github.com/smartmontools/smartmontools/releases/download/RELEASE_7_5/smartmontools-7.5.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 12 May 2025 07:04:43 GMT
URLDownloader: Storing new ETag header: "0x8DD912345A5F99C"
URLDownloader: Downloaded /Users/autopkg/Library/AutoPkg/Cache/com.github.apizz.download.smartmontools/downloads/smartmontools.dmg
{'Output': {'download_changed': True,
            'etag': '"0x8DD912345A5F99C"',
            'last_modified': 'Mon, 12 May 2025 07:04:43 GMT',
            'pathname': '/Users/autopkg/Library/AutoPkg/Cache/com.github.apizz.download.smartmontools/downloads/smartmontools.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/autopkg/Library/AutoPkg/Cache/com.github.apizz.download.smartmontools/downloads/smartmontools.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
FileFinder
{'Input': {'pattern': '/Users/autopkg/Library/AutoPkg/Cache/com.github.apizz.download.smartmontools/downloads/smartmontools.dmg/smartmontools*.pkg'}}
FileFinder: No value supplied for find_method, setting default value of: glob
FileFinder: Mounted disk image /Users/autopkg/Library/AutoPkg/Cache/com.github.apizz.download.smartmontools/downloads/smartmontools.dmg
FileFinder: Found file match: '/private/tmp/dmg.Fxgzi2/smartmontools-7.5-r5714.pkg' from globbed '/private/tmp/dmg.Fxgzi2/smartmontools*.pkg'
FileFinder: DMG-relative file match: 'smartmontools-7.5-r5714.pkg'
FileFinder: Basename match: 'smartmontools-7.5-r5714.pkg'
{'Output': {'dmg_found_filename': 'smartmontools-7.5-r5714.pkg',
            'found_basename': 'smartmontools-7.5-r5714.pkg',
            'found_filename': '/private/tmp/dmg.Fxgzi2/smartmontools-7.5-r5714.pkg'}}
FlatPkgUnpacker
{'Input': {'destination_path': '/Users/autopkg/Library/AutoPkg/Cache/com.github.apizz.download.smartmontools/unpack',
           'flat_pkg_path': '/Users/autopkg/Library/AutoPkg/Cache/com.github.apizz.download.smartmontools/downloads/smartmontools.dmg/smartmontools-7.5-r5714.pkg'}}
FlatPkgUnpacker: Mounted disk image /Users/autopkg/Library/AutoPkg/Cache/com.github.apizz.download.smartmontools/downloads/smartmontools.dmg
FlatPkgUnpacker: Unpacked /private/tmp/dmg.xvKzfv/smartmontools-7.5-r5714.pkg to /Users/autopkg/Library/AutoPkg/Cache/com.github.apizz.download.smartmontools/unpack
{'Output': {}}
com.facebook.autopkg.shared/PackageInfoVersioner
{'Input': {'package_info_path': '/Users/autopkg/Library/AutoPkg/Cache/com.github.apizz.download.smartmontools/unpack/PackageInfo'}}
PackageInfoVersioner: Found pkg_id com.smartmontools.pkg
PackageInfoVersioner: Found version 7.5
{'Output': {'pkg_id': 'com.smartmontools.pkg', 'version': '7.5'}}
PathDeleter
{'Input': {'path_list': ['/Users/autopkg/Library/AutoPkg/Cache/com.github.apizz.download.smartmontools/unpack']}}
PathDeleter: Deleted /Users/autopkg/Library/AutoPkg/Cache/com.github.apizz.download.smartmontools/unpack
{'Output': {}}
{'AUTOPKG_VERSION': '2.7.6',
 'CHECK_FILESIZE_ONLY': False,
 'CURL_PATH': '/usr/bin/curl',
 'GITHUB_TOKEN_PATH': '~/.autopkg_gh_token',
 'GITHUB_URL': 'https://api.github.com',
 'NAME': 'smartmontools',
 'PARENT_RECIPES': [],
 'RECIPE_CACHE_DIR': '/Users/autopkg/Library/AutoPkg/Cache/com.github.apizz.download.smartmontools',
 'RECIPE_DIR': '/Users/autopkg/Library/AutoPkg/RecipeRepos/com.github.autopkg.apizz-recipes/smartmontools',
 'RECIPE_OVERRIDE_DIRS': ['~/Library/AutoPkg/RecipeOverrides'],
 'RECIPE_PATH': '/Users/autopkg/Library/AutoPkg/RecipeRepos/com.github.autopkg.apizz-recipes/smartmontools/smartmontools.download.recipe',
 'RECIPE_REPOS': {'/Users/autopkg/Library/AutoPkg/RecipeRepos/com.github.autopkg.apizz-recipes': {'URL': 'https://github.com/autopkg/apizz-recipes'},
                  '/Users/autopkg/Library/AutoPkg/RecipeRepos/com.github.facebookarchive.Recipes-for-AutoPkg': {'URL': 'https://github.com/facebookarchive/Recipes-for-AutoPkg'}},
 'RECIPE_SEARCH_DIRS': ['.',
                        '~/Library/AutoPkg/Recipes',
                        '/Library/AutoPkg/Recipes',
                        '/Users/autopkg/Library/AutoPkg/RecipeRepos/com.github.autopkg.apizz-recipes',
                        '/Users/autopkg/Library/AutoPkg/RecipeRepos/com.github.facebookarchive.Recipes-for-AutoPkg'],
 'asset_created_at': '2025-05-12T07:04:42Z',
 'asset_regex': 'smartmontools-.*dmg$',
 'asset_url': 'https://api.github.com/repos/smartmontools/smartmontools/releases/assets/253859518',
 'destination_path': '/Users/autopkg/Library/AutoPkg/Cache/com.github.apizz.download.smartmontools/unpack',
 'dmg_found_filename': 'smartmontools-7.5-r5714.pkg',
 'download_changed': True,
 'etag': '"0x8DD912345A5F99C"',
 'filename': 'smartmontools.dmg',
 'find_method': 'glob',
 'flat_pkg_path': '/Users/autopkg/Library/AutoPkg/Cache/com.github.apizz.download.smartmontools/downloads/smartmontools.dmg/smartmontools-7.5-r5714.pkg',
 'found_basename': 'smartmontools-7.5-r5714.pkg',
 'found_filename': '/private/tmp/dmg.Fxgzi2/smartmontools-7.5-r5714.pkg',
 'github_repo': 'smartmontools/smartmontools',
 'include_prereleases': '%PRERELEASE%',
 'last_modified': 'Mon, 12 May 2025 07:04:43 GMT',
 'package_info_path': '/Users/autopkg/Library/AutoPkg/Cache/com.github.apizz.download.smartmontools/unpack/PackageInfo',
 'path_list': ['/Users/autopkg/Library/AutoPkg/Cache/com.github.apizz.download.smartmontools/unpack'],
 'pathname': '/Users/autopkg/Library/AutoPkg/Cache/com.github.apizz.download.smartmontools/downloads/smartmontools.dmg',
 'pattern': '/Users/autopkg/Library/AutoPkg/Cache/com.github.apizz.download.smartmontools/downloads/smartmontools.dmg/smartmontools*.pkg',
 'pkg_id': 'com.smartmontools.pkg',
 'prefetch_filename': False,
 'release_notes': '- CI and release builds are now reproducible if same '
                  'SOURCE_DATE_EPOCH,\r\n'
                  '  build recipes and toolchains are used.\r\n'
                  "- smartctl `-j -A`: New JSON value 'endurance_used' "
                  '(ATA/SCSI/NVMe).\r\n'
                  "- smartctl `-j -A`: New JSON value 'spare_available' "
                  '(ATA/NVMe).\r\n'
                  "- smartctl `-j -i`: Re-added the JSON value 'model_name' "
                  'also for SCSI\r\n'
                  '  devices (regression).\r\n'
                  '- smartctl `-j -c`: NVMe support.\r\n'
                  "- smartctl `-j -n ...`: New JSON values 'power_mode.*' (ATA "
                  'only).\r\n'
                  '- smartctl `-H -A`: Support for NVMe SMART/Health '
                  'Information per\r\n'
                  '  namespace.\r\n'
                  '- smartctl `-i`: ATA ACS-6 updates.\r\n'
                  '- smartctl `-x`: No longer includes `-g wcreorder`.\r\n'
                  '- smartctl `-x`, `-l scterc`: No longer returns exit status '
                  '4 if SCT ERC\r\n'
                  '  is not supported by the device.\r\n'
                  '- smartctl `-l error`: No longer prints bogus ATA error log '
                  'entries if\r\n'
                  '  the error index is nonzero but the error count is '
                  'zero.\r\n'
                  '- smartctl `-l ssd`: Fixed corruption of the output of the '
                  'SCSI Format\r\n'
                  '  Status log page.\r\n'
                  "- smartctl `-l ssd`: Now detects 'no format since "
                  "manufacture' from the\r\n"
                  '  SCSI Format Status log page.\r\n'
                  "- smartctl `-l farm`: Fixed the unit of 'Write Power On' "
                  'time.\r\n'
                  "- smartctl `-l farm`: Fixed the byte order of ATA 'Assembly "
                  "Date'.\r\n"
                  '- smartctl `-l farm`: Fixed a possible segfault.\r\n'
                  '- smartctl `-l farm -q noserial`: Suppresses serial and WWN '
                  'also from FARM.\r\n'
                  '- smartctl `-l farm -T permissive`: Overrides false '
                  'negative FARM support\r\n'
                  '  check for rebranded drives.\r\n'
                  '- smartctl `-t TEST`: Fixed self-tests of single namespace '
                  'NVMe devices.\r\n'
                  '- smartd `-A`: NVMe attribute log support.\r\n'
                  '- smartd: Ignores NSID in duplicate check of single '
                  'namespace devices.\r\n'
                  "- smartd: No longer issues LOG_CRIT warnings for 'Set "
                  "Feature' related\r\n"
                  '  NVMe error information log entries.\r\n'
                  '- smartd: No longer hangs on systems with large file '
                  'descriptor limits.\r\n'
                  '- smartd: No longer logs invalid "old test ... not run" '
                  'messages if\r\n'
                  '  staggered self-tests are used.\r\n'
                  '- smartd.conf `-l selftest[sts] -s ...`: NVMe self-test '
                  'support.\r\n'
                  '- smartd.conf `-H MASK`: Ability to ignore specific bits of '
                  'NVMe\r\n'
                  "  SMART/Health value 'Critical Warning'.\r\n"
                  '- smartd.conf `-p`: Checks NVMe SMART/Health value '
                  "'Available Spare'.\r\n"
                  '- smartd.conf `-u [-f]`: Checks NVMe SMART/Health values '
                  "'Percentage Used'\r\n"
                  "  and 'Media and Data Integrity Errors'.\r\n"
                  '- smartd.conf `-W ...`: No longer includes individual '
                  'sensors in NVMe\r\n'
                  '  temperature check as some devices report other values '
                  'there.\r\n'
                  '- ATA: Device type `-d jmb39x-q2,N` for another JMB39x '
                  'protocol variant\r\n'
                  '  used by QNAP-TR002 NAS devices.\r\n'
                  '- SCSI: Fixed range checks of mode page offset and VPD '
                  'inquiry.\r\n'
                  '- SCSI: Fixed buffer overflow parsing of VPD page.\r\n'
                  '- SCSI: Fixed handling of multiple designators in VPD '
                  'page.\r\n'
                  '- USB/NVMe: `-d sntjmicron` no longer triggers USB resets '
                  'on queries of\r\n'
                  '  the self-test log.\r\n'
                  '- USB/NVMe: `-d sntasmedia` now supports log pages > 512 '
                  'bytes.\r\n'
                  '- USB/NVMe/SAT: New experimental NVMe/SAT autodetection '
                  'options\r\n'
                  '  `-d snt*/sat`.\r\n'
                  '- Fixed segfault on missing option argument on systems '
                  'using musl libc.\r\n'
                  '- HDD, SSD and USB additions to drive database.\r\n'
                  '- automake < 1.13 are no longer supported.\r\n'
                  '- Custom make rules are now silenced if `make V=0` is '
                  'used.\r\n'
                  '- Enhanced makefile targets `dist-*` to create reproducible '
                  'source\r\n'
                  '  tarballs if SOURCE_DATE_EPOCH is set.\r\n'
                  '- The makefile no longer uses GNU make specific syntax '
                  'elements\r\n'
                  '  (exception: reproducible builds for macOS).\r\n'
                  '- Dropped support for platforms without `sigaction()`.\r\n'
                  '- configure: Now also detects MidnightBSD.\r\n'
                  '- configure: Dropped option `--with-signal-func`.\r\n'
                  '- configure: Default for `--with-nvme-devicescan` is now '
                  "'yes' also on\r\n"
                  '  NetBSD.\r\n'
                  '- Version information is now also set if build from GH R/O '
                  'mirror.\r\n'
                  '- Linux: `smartd.service` now avoids a warning about an '
                  'unset environment\r\n'
                  '  variable.\r\n'
                  '- Linux: Dropped autodetection of deprecated device type '
                  '`-d marvell`.\r\n'
                  '- macOS: Support for reproducible builds of the DMG '
                  'image.\r\n'
                  '- OpenBSD: NVMe support.\r\n'
                  '- Windows: Increased WMI timeout.\r\n'
                  '- Windows: Support for reproducible builds of the '
                  'installer.\r\n'
                  '- Windows: Uninstaller is no longer damaged if the '
                  'installer is signed.\r\n'
                  '- Windows `update-smartd-drivedb.ps1`: Fixed call of '
                  '`gpg.exe` if it\r\n'
                  '  appears more than once in the PATH.\r\n'
                  '- Windows `update-smartd-drivedb.ps1 -Verbose`: Now also '
                  'prints the\r\n'
                  '  download command.\r\n',
 'url': 'https://github.com/smartmontools/smartmontools/releases/download/RELEASE_7_5/smartmontools-7.5.dmg',
 'url_downloader_summary_result': {'data': {'download_path': '/Users/autopkg/Library/AutoPkg/Cache/com.github.apizz.download.smartmontools/downloads/smartmontools.dmg'},
                                   'summary_text': 'The following new items '
                                                   'were downloaded:'},
 'verbose': 3,
 'version': '7.5'}
Receipt written to /Users/autopkg/Library/AutoPkg/Cache/com.github.apizz.download.smartmontools/receipts/smartmontools.download-receipt-20251014-234045.plist

The following new items were downloaded:
    Download Path                                                                                         
    -------------                                                                                         
    /Users/autopkg/Library/AutoPkg/Cache/com.github.apizz.download.smartmontools/downloads/smartmontools.dmg
```