### PR TITLE
Update ETCnomad Munki recipe

### DIFF
--- a/ETCnomad/ETCnomad.munki.recipe
+++ b/ETCnomad/ETCnomad.munki.recipe
@@ -3,11 +3,15 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest version of ETCnomad, extracts a PKG, and imports it into a munki_repo.</string>
+    <string>Downloads the latest version of ETCnomad, extracts a PKG, and imports it into a munki_repo.
+
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
     <key>Identifier</key>
     <string>com.github.apizz.munki.ETCnomad</string>
     <key>Input</key>
     <dict>
+        <key>DERIVE_MIN_OS</key>
+        <string>YES</string>
         <key>MUNKI_CATEGORY</key>
         <string>Lighting</string>
         <key>MUNKI_REPO_SUBDIR</key>
@@ -30,8 +34,6 @@
 It can serve as a primary controller, a backup, or a client device – or work offline entirely – operating on either a PC platform running Microsoft Windows® 7 or higher, or natively on a Mac running Mojave (v10.14) or later.</string>
             <key>display_name</key>
             <string>ETCnomad</string>
-            <key>minimum_os_version</key>
-            <string>10.14</string>
             <key>name</key>
             <string>%NAME%</string>
             <key>unattended_install</key>
@@ -39,11 +41,90 @@ It can serve as a primary controller, a backup, or a client device – or work o
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.6.1</string>
+    <string>2.7</string>
     <key>ParentRecipe</key>
     <string>com.github.apizz.pkg.ETCnomad</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked</string>
+                <key>flat_pkg_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%.pkg</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>FlatPkgUnpacker</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pattern</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked/ETCnomad_Eos_*.pkg</string>
+            </dict>
+            <key>Processor</key>
+            <string>FileFinder</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/payload</string>
+                <key>pkg_payload_path</key>
+                <string>%found_filename%/Payload</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>PkgPayloadUnpacker</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>derive_minimum_os_version</key>
+                <string>%DERIVE_MIN_OS%</string>
+                <key>version_comparison_key</key>
+                <string>CFBundleVersion</string>
+                <key>faux_root</key>
+                <string>%RECIPE_CACHE_DIR%/payload</string>
+                <key>installs_item_paths</key>
+                <array>
+                    <string>/Applications/Eos Family Welcome Screen.app</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_plist_path</key>
+                <string>%RECIPE_CACHE_DIR%/payload/Applications/Eos Family Welcome Screen.app/Contents/Info.plist</string>
+                <key>plist_version_key</key>
+                <string>CFBundleVersion</string>
+            </dict>
+            <key>Processor</key>
+            <string>Versioner</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>version</key>
+                    <string>%version%</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
         <dict>
             <key>Arguments</key>
             <dict>
@@ -61,6 +142,8 @@ It can serve as a primary controller, a backup, or a client device – or work o
                 <key>path_list</key>
                 <array>
                     <string>%RECIPE_CACHE_DIR%/unzip</string>
+                    <string>%RECIPE_CACHE_DIR%/payload</string>
+                    <string>%RECIPE_CACHE_DIR%/unpacked</string>
                 </array>
             </dict>
             <key>Processor</key>


### PR DESCRIPTION
Hi, @apizz 

The ETCnomad Munki recipe _is_ currently completing without error, but the latest version isn't being imported in to Munki. 

After investigating it appears that the developer hasn't updated the pkg receipt to match the latest version. 

<img width="603" height="185" alt="Screenshot 2025-10-15 at 16 07 44" src="https://github.com/user-attachments/assets/69bc01bf-f1c7-419a-a133-787afdcf65cb" />


This PR adds in steps to create an installs array with the comparison key set to `CFBundleVersion` which matches the vendors latest release, and tidy up after.

Output from a successful -v run 
```
autopkg run -v ETCnomad.munki.recipe
Processing ETCnomad.munki.recipe...
WARNING: ETCnomad.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (url): /WorkArea/DownloadAsset.aspx?id=10737519744
URLTextSearcher: Found matching text (match): /WorkArea/DownloadAsset.aspx?id=10737519744
URLDownloader
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.ETCnomad/downloads/ETCnomad.zip
EndOfCheckPhase
Unarchiver
Unarchiver: Guessed archive format 'zip' from filename ETCnomad.zip
Unarchiver: Unarchived /Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.ETCnomad/downloads/ETCnomad.zip to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.ETCnomad/unzip
FileFinder
FileFinder: Found file match: '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.ETCnomad/unzip/ETCnomad Eos Mac 3.3.2.36.pkg' from globbed '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.ETCnomad/unzip/*.pkg'
FileFinder: Basename match: 'ETCnomad Eos Mac 3.3.2.36.pkg'
CodeSignatureVerifier
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "ETCnomad Eos Mac 3.3.2.36.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2025-10-02 16:14:19 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Electronic Theatre Controls, Inc. (8AVSFD7ZED)
CodeSignatureVerifier:        Expires: 2029-03-29 13:23:04 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            61 BD D8 42 82 4E 28 A2 6A D6 5A 65 1C 2A EE CB 00 D6 DE 1A 34 1B 
CodeSignatureVerifier:            4A F6 D9 03 17 1C 0A AF 2D C9
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2031-09-17 00:00:00 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            F1 6C D3 C5 4C 7F 83 CE A4 BF 1A 3E 6A 08 19 C8 AA A8 E4 A1 52 8F 
CodeSignatureVerifier:            D1 44 71 5F 35 06 43 D2 DF 3A
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
PkgCopier
PkgCopier: Copied /Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.ETCnomad/unzip/ETCnomad Eos Mac 3.3.2.36.pkg to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.ETCnomad/ETCnomad.pkg
FlatPkgUnpacker
FlatPkgUnpacker: Unpacked /Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.ETCnomad/ETCnomad.pkg to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.ETCnomad/unpacked
FileFinder
FileFinder: Found file match: '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.ETCnomad/unpacked/ETCnomad_Eos_3.3.2.36.pkg' from globbed '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.ETCnomad/unpacked/ETCnomad_Eos_*.pkg'
FileFinder: Basename match: 'ETCnomad_Eos_3.3.2.36.pkg'
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked /Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.ETCnomad/unpacked/ETCnomad_Eos_3.3.2.36.pkg/Payload to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.ETCnomad/payload
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/Eos Family Welcome Screen.app
MunkiInstallsItemsCreator: Derived minimum os version as: 10.14
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.ETC.EosWelcomeScreen', 'CFBundleName': 'Eos Family Welcome Screen', 'CFBundleShortVersionString': '3.3.2', 'CFBundleVersion': '3.3.2.36', 'minosversion': '10.14', 'path': '/Applications/Eos Family Welcome Screen.app', 'type': 'application', 'version_comparison_key': 'CFBundleVersion'}], 'minimum_os_version': '10.14'} into pkginfo
Versioner
Versioner: Found version 3.3.2.36 in file /Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.ETCnomad/payload/Applications/Eos Family Welcome Screen.app/Contents/Info.plist
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'version': '3.3.2.36'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/etcnomad/ETCnomad-3.3.2.36.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/etcnomad/ETCnomad-3.3.2.36.pkg
PathDeleter
PathDeleter: Deleted /Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.ETCnomad/unzip
PathDeleter: Deleted /Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.ETCnomad/payload
PathDeleter: Deleted /Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.ETCnomad/unpacked
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.ETCnomad/receipts/ETCnomad.munki-receipt-20251015-155708.plist

The following packages were copied:
    Pkg Path                                                                               
    --------                                                                               
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.apizz.munki.ETCnomad/ETCnomad.pkg  

The following new items were imported into Munki:
    Name      Version   Catalogs  Pkginfo Path                           Pkg Repo Path                        Icon Repo Path  
    ----      -------   --------  ------------                           -------------                        --------------  
    ETCnomad  3.3.2.36  testing   apps/etcnomad/ETCnomad-3.3.2.36.plist  apps/etcnomad/ETCnomad-3.3.2.36.pkg
```