### PR TITLE
Deprecate Dash6 recipes

### DIFF
--- a/Dash/Dash6.download.recipe
+++ b/Dash/Dash6.download.recipe
@@ -14,6 +14,15 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the Dash recipes in the hjuutilainen-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>filename</key>


### PR DESCRIPTION
Dash 6 is no longer being updated. The latest version is Dash 8. The hjuutilainen-recipes repo has Dash recipes with a `MAJOR_VERSION` input variable that work with all the recent versions from 4 through 8. This PR deprecates the ones in this repo in favor of those more flexible alternatives.

Thanks for considering!