### PR TITLE
Fix misplaced processor arguments

### DIFF
--- a/Pencil2D/Pencil2D.download.recipe
+++ b/Pencil2D/Pencil2D.download.recipe
@@ -47,7 +47,7 @@
         <string>EndOfCheckPhase</string>
       </dict>
       <dict>
-        <key>Arugments</key>
+        <key>Arguments</key>
         <dict>
           <key>archive_path</key>
           <string>%pathname%</string>

--- a/Sqwarq/CriticalUpdates.download.recipe
+++ b/Sqwarq/CriticalUpdates.download.recipe
@@ -38,7 +38,7 @@
             <string>EndOfCheckPhase</string>
         </dict>
         <dict>
-            <key>Arugments</key>
+            <key>Arguments</key>
             <dict>
                 <key>archive_path</key>
                 <string>%pathname%</string>

--- a/Sqwarq/FastTasks2.download.recipe
+++ b/Sqwarq/FastTasks2.download.recipe
@@ -38,7 +38,7 @@
             <string>EndOfCheckPhase</string>
         </dict>
         <dict>
-            <key>Arugments</key>
+            <key>Arguments</key>
             <dict>
                 <key>archive_path</key>
                 <string>%pathname%</string>


### PR DESCRIPTION
This PR ensures that typos or indentation doesn't prevent Arguments from being properly detected within each Processor.

Thanks for considering!

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.3.0.